### PR TITLE
Announce deployment outcomes instead of making the user watch

### DIFF
--- a/internal/tui/deploy_watch.go
+++ b/internal/tui/deploy_watch.go
@@ -1,0 +1,85 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/resetnak/cooldeck/internal/app"
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+)
+
+// deploymentOutcomes compares a freshly loaded snapshot against the statuses
+// seen on the previous refresh and announces the deployments that just settled.
+// The dashboard already polls this data, so noticing the transition costs one
+// map instead of another request.
+//
+// Only a transition observed here counts. The first snapshot after startup or
+// an instance switch is full of history that settled long ago, and replaying it
+// as notifications would be worse than saying nothing.
+func (m *Model) deploymentOutcomes(snapshot app.DashboardSnapshot) []tea.Cmd {
+	seen := make(map[string]domain.DeploymentStatus,
+		len(snapshot.ActiveDeployments)+len(snapshot.RecentDeployments))
+
+	var cmds []tea.Cmd
+	for _, list := range [][]domain.Deployment{snapshot.ActiveDeployments, snapshot.RecentDeployments} {
+		for _, d := range list {
+			if d.UUID == "" {
+				continue
+			}
+			if _, dup := seen[d.UUID]; dup {
+				// A deployment can appear in both lists; the first wins.
+				continue
+			}
+			seen[d.UUID] = d.Status
+
+			prev, known := m.deployStates[d.UUID]
+			if !known || !prev.IsActive() || d.Status.IsActive() {
+				continue
+			}
+			if cmd := m.deploymentOutcomeToast(d); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			// The deployment has settled, so the session no longer owns it.
+			delete(m.ownDeploys, d.UUID)
+		}
+	}
+
+	m.deployStates = seen
+	return cmds
+}
+
+// deploymentOutcomeToast is the notification for one settled deployment, or nil
+// when the outcome is not worth interrupting for. A failure always speaks up
+// because it is the whole reason to watch. A success only does when this
+// session triggered it: on an instance that CI and colleagues also deploy to,
+// announcing every green build buries the one red one.
+func (m *Model) deploymentOutcomeToast(d domain.Deployment) tea.Cmd {
+	name := d.ApplicationName
+	if name == "" {
+		name = d.ApplicationUUID
+	}
+
+	switch d.Status {
+	case domain.DeploymentFailed:
+		return m.pushToast(components.ToastError, "Deploy failed", name+" - press 2 for the queue")
+	case domain.DeploymentCancelled:
+		if !m.ownDeploys[d.UUID] {
+			return nil
+		}
+		return m.pushToast(components.ToastWarning, "Deploy cancelled", name)
+	case domain.DeploymentFinished:
+		if !m.ownDeploys[d.UUID] {
+			return nil
+		}
+		return m.pushToast(components.ToastSuccess, "Deploy finished", name)
+	default:
+		return nil
+	}
+}
+
+// forgetDeploymentStates drops the watch state so a different instance cannot
+// inherit another fleet's deployments.
+func (m *Model) forgetDeploymentStates() {
+	m.deployStates = map[string]domain.DeploymentStatus{}
+	m.ownDeploys = map[string]bool{}
+}

--- a/internal/tui/deploy_watch_test.go
+++ b/internal/tui/deploy_watch_test.go
@@ -1,0 +1,110 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/resetnak/cooldeck/internal/app"
+	"github.com/resetnak/cooldeck/internal/app/demo"
+	"github.com/resetnak/cooldeck/internal/config"
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+)
+
+func newWatchModel() *Model {
+	return New(Options{Config: config.Default(), Service: demo.New(demo.Options{}), Demo: true, ASCII: true})
+}
+
+func activeSnapshot(uuid string) app.DashboardSnapshot {
+	return app.DashboardSnapshot{ActiveDeployments: []domain.Deployment{
+		{UUID: uuid, ApplicationName: "api", Status: domain.DeploymentInProgress},
+	}}
+}
+
+func settledSnapshot(uuid string, status domain.DeploymentStatus) app.DashboardSnapshot {
+	return app.DashboardSnapshot{RecentDeployments: []domain.Deployment{
+		{UUID: uuid, ApplicationName: "api", Status: status},
+	}}
+}
+
+// onlyToast runs the commands and returns the single toast they produced.
+func onlyToast(t *testing.T, cmds []tea.Cmd) toastMsg {
+	t.Helper()
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(cmds))
+	}
+	toast, ok := cmds[0]().(toastMsg)
+	if !ok {
+		t.Fatalf("command did not produce a toast")
+	}
+	return toast
+}
+
+func TestDeploymentFailureNotifiesOnceOnTransition(t *testing.T) {
+	model := newWatchModel()
+
+	// History loaded at startup has settled long ago and must stay silent.
+	if cmds := model.deploymentOutcomes(settledSnapshot("d1", domain.DeploymentFailed)); len(cmds) != 0 {
+		t.Fatalf("first snapshot notified %d times, want 0", len(cmds))
+	}
+
+	model = newWatchModel()
+	if cmds := model.deploymentOutcomes(activeSnapshot("d1")); len(cmds) != 0 {
+		t.Fatalf("in-flight deployment notified %d times, want 0", len(cmds))
+	}
+
+	toast := onlyToast(t, model.deploymentOutcomes(settledSnapshot("d1", domain.DeploymentFailed)))
+	if toast.Kind != int(components.ToastError) {
+		t.Fatalf("toast kind = %d, want error", toast.Kind)
+	}
+
+	// The status does not change again, so neither should the notification.
+	if cmds := model.deploymentOutcomes(settledSnapshot("d1", domain.DeploymentFailed)); len(cmds) != 0 {
+		t.Fatalf("repeat snapshot notified %d times, want 0", len(cmds))
+	}
+}
+
+func TestDeploymentSuccessNotifiesOnlyForOwnDeploys(t *testing.T) {
+	model := newWatchModel()
+
+	// Someone else's green build is noise.
+	model.deploymentOutcomes(activeSnapshot("d1"))
+	if cmds := model.deploymentOutcomes(settledSnapshot("d1", domain.DeploymentFinished)); len(cmds) != 0 {
+		t.Fatalf("foreign success notified %d times, want 0", len(cmds))
+	}
+
+	// A deploy triggered here is claimed when Coolify accepts it.
+	model.Update(actionCompletedMsg{
+		Seq:    model.operationSeq,
+		Result: app.OperationResult{Operation: "deploy", DeploymentUUID: "d2"},
+	})
+	if !model.ownDeploys["d2"] {
+		t.Fatal("queued deployment was not claimed by the session")
+	}
+
+	model.deploymentOutcomes(activeSnapshot("d2"))
+	toast := onlyToast(t, model.deploymentOutcomes(settledSnapshot("d2", domain.DeploymentFinished)))
+	if toast.Kind != int(components.ToastSuccess) {
+		t.Fatalf("toast kind = %d, want success", toast.Kind)
+	}
+
+	// Ownership ends with the deployment, so the map cannot grow all session.
+	if model.ownDeploys["d2"] {
+		t.Fatal("settled deployment is still claimed")
+	}
+}
+
+func TestInstanceSwitchForgetsDeploymentStates(t *testing.T) {
+	model := newWatchModel()
+	model.deploymentOutcomes(activeSnapshot("d1"))
+	model.ownDeploys["d1"] = true
+
+	model.forgetDeploymentStates()
+
+	// Without the reset, a deployment UUID reused by another fleet would be
+	// reported as a transition it never made.
+	if cmds := model.deploymentOutcomes(settledSnapshot("d1", domain.DeploymentFailed)); len(cmds) != 0 {
+		t.Fatalf("stale state notified %d times, want 0", len(cmds))
+	}
+}

--- a/internal/tui/instance_switch.go
+++ b/internal/tui/instance_switch.go
@@ -56,6 +56,7 @@ func (m *Model) applyInstanceSwitch(msg instanceSwitchedMsg) tea.Cmd {
 	m.apps = views.NewApplications()
 	m.detail = views.NewDetail()
 	m.deployments = views.NewDeployments()
+	m.forgetDeploymentStates()
 	m.screen = screenList
 	m.section = SectionApplications
 	m.focus = focusContent

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -214,6 +214,14 @@ type Model struct {
 	pendingAction     *pendingAction
 	operationInFlight bool
 
+	// deployStates is the deployment status seen on the previous refresh, keyed
+	// by deployment UUID. It is rebuilt from every snapshot, so it cannot grow
+	// past what the instance itself reports.
+	deployStates map[string]domain.DeploymentStatus
+	// ownDeploys marks deployments this session triggered. Their success is
+	// worth announcing; someone else's is not.
+	ownDeploys map[string]bool
+
 	toasts     []components.Toast
 	nextToast  int
 	spinnerIdx int
@@ -259,6 +267,8 @@ func New(opts Options) *Model {
 		connection:   components.ConnectionConnecting,
 		loading:      true,
 		capabilities: app.FullCapabilities(),
+		deployStates: map[string]domain.DeploymentStatus{},
+		ownDeploys:   map[string]bool{},
 	}
 	m.forceCompact = opts.Config.UI.CompactMode == config.TristateOn
 	m.rebuildTheme()
@@ -353,7 +363,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.deployments.SetItems(recent, msg.Snapshot.LoadedAt)
 		m.syncDetailFromList()
 		m.refreshDiagnostics()
-		var cmds []tea.Cmd
+		cmds := m.deploymentOutcomes(msg.Snapshot)
 		for _, w := range msg.Snapshot.Warnings {
 			cmds = append(cmds, m.pushToast(components.ToastWarning, w, ""))
 		}
@@ -436,6 +446,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.operationInFlight = false
 		m.cancelOperation = nil
 		m.capabilities = m.service.Capabilities()
+		if msg.Result.DeploymentUUID != "" {
+			// Remember it so the outcome is announced, not just the acceptance.
+			m.ownDeploys[msg.Result.DeploymentUUID] = true
+		}
 		return m, tea.Batch(
 			m.pushToast(components.ToastSuccess, "Action queued", "Coolify accepted the "+msg.Result.Operation+" request."),
 			m.manualRefresh(),


### PR DESCRIPTION
Everything in cooldeck today is a *view* — you look at it and it tells you the state at that moment. The one thing with latency is a deploy: you press `d`, confirm, and then have to babysit the screen. A dashboard that cannot tell you the build failed is asking you to poll it manually, which is the job it exists to do for you.

The data was already there. `refreshTick` reloads the dashboard on a timer and every `dashboardLoadedMsg` carries `ActiveDeployments` and `RecentDeployments` — the model just overwrote them without ever comparing against the previous snapshot.

## What it does

`deploymentOutcomes` diffs each snapshot against the statuses seen on the previous refresh and toasts what just settled:

| Outcome | Behaviour |
|---|---|
| `failed` | Always — error toast, pointing at the queue (`2`) |
| `finished` | Only if this session queued it — success toast |
| `cancelled` | Only if this session queued it — warning toast |

Failures always speak up because that is the whole reason to watch. Successes are gated on ownership: on an instance CI and colleagues also deploy to, announcing every green build buries the one red one. Ownership is claimed from `OperationResult.DeploymentUUID` when Coolify accepts the request, and released once the deployment settles.

## Two deliberate choices

**The first snapshot is silent.** A notification only comes from a transition observed at runtime. Without that guard, startup would dump a toast for every historical deployment the instance still lists, some of which finished last week.

**Instance switch forgets everything.** `forgetDeploymentStates` sits with the other cache resets, so a UUID recycled by another fleet cannot be reported as a transition it never made.

## Cost

No new `app.Service` method, no new request, no new DTO, no new view, no golden churn. One map, one comparison, ~85 lines.

## Testing

`make check` and `staticcheck` clean. Three tests cover what could plausibly break: startup history stays silent, a failure notifies exactly once and a repeated snapshot does not re-notify, a foreign success is silent while an owned one is not, and an instance switch drops the state.

Verifiable offline — the demo service returns a real `DeploymentUUID` from `Deploy` and finishes the build on its own:

```
make run  →  d on an application  →  confirm  →  "Deploy finished"
```

https://claude.ai/code/session_01YU2MN5vUbJkE3v9j2sVuvn