### PR TITLE
Show how long a build has been running against how long it usually takes

### DIFF
--- a/internal/domain/application.go
+++ b/internal/domain/application.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -247,4 +248,81 @@ func ShortSHA(sha string) string {
 		return sha[:7]
 	}
 	return sha
+}
+
+// BaselineDuration is the median run time of the most recent successful
+// deployments of one application, used to judge whether an in-flight build is
+// taking longer than that application usually does. It returns zero when there
+// is no usable history, which callers must treat as "no expectation to show"
+// rather than "instant".
+//
+// Only finished deployments count. A failed or cancelled build stops for
+// reasons that say nothing about how long a successful one takes, and letting
+// a build that died after ten seconds drag the median down would make every
+// normal build look overdue.
+//
+// The median over a small sample is deliberate: one pathological run - a cold
+// cache, a slow registry - should not move the number a user is shown.
+func BaselineDuration(deployments []Deployment, appUUID string, sample int) time.Duration {
+	if sample <= 0 {
+		return 0
+	}
+
+	// Order is not guaranteed by the caller, and "most recent" has to mean
+	// exactly that for the baseline to track a project as it grows.
+	ordered := make([]Deployment, 0, len(deployments))
+	for _, d := range deployments {
+		if d.Status != DeploymentFinished {
+			continue
+		}
+		if appUUID != "" && d.ApplicationUUID != appUUID {
+			continue
+		}
+		ordered = append(ordered, d)
+	}
+	slices.SortFunc(ordered, func(a, b Deployment) int {
+		return b.deploymentStart().Compare(a.deploymentStart())
+	})
+
+	durations := make([]time.Duration, 0, sample)
+	for _, d := range ordered {
+		if len(durations) == sample {
+			break
+		}
+		// Duration falls back to now for an unfinished deployment, but these are
+		// all finished, so the zero check only skips malformed history.
+		if run := d.Duration(d.finishedOrStart()); run > 0 {
+			durations = append(durations, run)
+		}
+	}
+	if len(durations) == 0 {
+		return 0
+	}
+
+	slices.Sort(durations)
+	mid := len(durations) / 2
+	if len(durations)%2 == 1 {
+		return durations[mid]
+	}
+	return (durations[mid-1] + durations[mid]) / 2
+}
+
+// deploymentStart is the best available start time, matching what Duration uses.
+func (d Deployment) deploymentStart() time.Time {
+	if !d.StartedAt.IsZero() {
+		return d.StartedAt
+	}
+	return d.CreatedAt
+}
+
+// finishedOrStart gives Duration a reference point that cannot drift with the
+// clock, so a historical duration is stable across refreshes.
+func (d Deployment) finishedOrStart() time.Time {
+	if d.FinishedAt != nil {
+		return *d.FinishedAt
+	}
+	if !d.UpdatedAt.IsZero() {
+		return d.UpdatedAt
+	}
+	return d.deploymentStart()
 }

--- a/internal/domain/baseline_test.go
+++ b/internal/domain/baseline_test.go
@@ -1,0 +1,116 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+// finished builds a completed deployment of the given app that ran for d,
+// started `ago` before a fixed reference point.
+func finished(app string, ago, d time.Duration) Deployment {
+	start := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).Add(-ago)
+	end := start.Add(d)
+	return Deployment{
+		ApplicationUUID: app,
+		Status:          DeploymentFinished,
+		StartedAt:       start,
+		FinishedAt:      &end,
+	}
+}
+
+func TestBaselineDurationTakesTheMedianOfTheNewestRuns(t *testing.T) {
+	deployments := []Deployment{
+		// Deliberately out of order: the caller's ordering is not guaranteed,
+		// and "most recent" has to mean most recent for the estimate to track a
+		// project that grows heavier.
+		finished("app", 3*time.Hour, 60*time.Second),
+		finished("app", 1*time.Hour, 40*time.Second),
+		finished("app", 2*time.Hour, 50*time.Second),
+		// Older than the sample window, and wildly slow: must not count.
+		finished("app", 99*time.Hour, 90*time.Minute),
+	}
+
+	if got := BaselineDuration(deployments, "app", 3); got != 50*time.Second {
+		t.Fatalf("baseline = %s, want 50s", got)
+	}
+}
+
+func TestBaselineDurationIgnoresOtherApplications(t *testing.T) {
+	deployments := []Deployment{
+		finished("app", time.Hour, 30*time.Second),
+		finished("other", time.Hour, 30*time.Minute),
+	}
+
+	if got := BaselineDuration(deployments, "app", 5); got != 30*time.Second {
+		t.Fatalf("baseline = %s, want 30s", got)
+	}
+}
+
+func TestBaselineDurationCountsOnlySuccesses(t *testing.T) {
+	start := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Second)
+
+	// A build that died after two seconds says nothing about how long a
+	// successful one takes; counting it would make every normal build look
+	// overdue.
+	deployments := []Deployment{
+		finished("app", time.Hour, 60*time.Second),
+		{ApplicationUUID: "app", Status: DeploymentFailed, StartedAt: start, FinishedAt: &end},
+		{ApplicationUUID: "app", Status: DeploymentCancelled, StartedAt: start, FinishedAt: &end},
+		{ApplicationUUID: "app", Status: DeploymentInProgress, StartedAt: start},
+	}
+
+	if got := BaselineDuration(deployments, "app", 5); got != 60*time.Second {
+		t.Fatalf("baseline = %s, want 60s", got)
+	}
+}
+
+func TestBaselineDurationAveragesTheMiddlePairWhenEven(t *testing.T) {
+	deployments := []Deployment{
+		finished("app", time.Hour, 10*time.Second),
+		finished("app", 2*time.Hour, 20*time.Second),
+		finished("app", 3*time.Hour, 30*time.Second),
+		finished("app", 4*time.Hour, 60*time.Second),
+	}
+
+	if got := BaselineDuration(deployments, "app", 4); got != 25*time.Second {
+		t.Fatalf("baseline = %s, want 25s", got)
+	}
+}
+
+func TestBaselineDurationIsZeroWithoutUsableHistory(t *testing.T) {
+	cases := map[string][]Deployment{
+		"no deployments at all": nil,
+		"none finished": {
+			{ApplicationUUID: "app", Status: DeploymentInProgress},
+		},
+		"none for this application": {
+			finished("other", time.Hour, time.Minute),
+		},
+	}
+
+	for name, deployments := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Zero means "no expectation to show". A caller that treats it as a
+			// duration would draw a full bar the instant a build starts.
+			if got := BaselineDuration(deployments, "app", 5); got != 0 {
+				t.Fatalf("baseline = %s, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBaselineDurationHistoricalRunsDoNotDriftWithTheClock(t *testing.T) {
+	deployments := []Deployment{finished("app", time.Hour, 45*time.Second)}
+
+	first := BaselineDuration(deployments, "app", 5)
+	// Duration() measures an unfinished deployment against now; a finished one
+	// must be measured against its own end, or the baseline would grow forever.
+	time.Sleep(2 * time.Millisecond)
+	if second := BaselineDuration(deployments, "app", 5); second != first {
+		t.Fatalf("baseline moved from %s to %s", first, second)
+	}
+	if first != 45*time.Second {
+		t.Fatalf("baseline = %s, want 45s", first)
+	}
+}

--- a/internal/tui/components/progress.go
+++ b/internal/tui/components/progress.go
@@ -1,0 +1,54 @@
+package components
+
+import (
+	"strings"
+	"time"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/theme"
+)
+
+// barCells is the width of the bar itself. Eight cells is enough to read at a
+// glance and leaves room for the label inside a table column.
+const barCells = 8
+
+// DurationBar renders how long an in-flight deployment has been running against
+// how long this application usually takes.
+//
+// It deliberately never shows a percentage. Coolify cannot say how far a build
+// has actually got, so a number like "60%" would be a claim the UI has no way
+// to back up - and the first slow build would expose it. What it shows is
+// elapsed against an expectation, and once that expectation is passed it stops
+// estimating and reports how far over it has gone, which is the point at which
+// the user should go and look at the logs.
+//
+// An empty string means there is nothing worth drawing: no baseline to compare
+// against, or a deployment that is not running.
+func DurationBar(th *theme.Theme, elapsed, baseline time.Duration) string {
+	if baseline <= 0 || elapsed < 0 {
+		return ""
+	}
+
+	filled := barCells
+	label := "+" + domain.HumanizeDuration(elapsed-baseline)
+	style, labelStyle := th.Attention, th.Attention
+	if elapsed < baseline {
+		// Round down, so the bar only reads as full when it genuinely is.
+		filled = int(int64(barCells) * int64(elapsed) / int64(baseline))
+		label = "~" + domain.HumanizeDuration(baseline)
+		style, labelStyle = th.Accent, th.Subtle
+	}
+	filled = max(min(filled, barCells), 0)
+
+	bar := style.Render(strings.Repeat(th.Sym.BarFull, filled)) +
+		th.Subtle.Render(strings.Repeat(th.Sym.BarEmpty, barCells-filled))
+	return bar + " " + labelStyle.Render(label)
+}
+
+// DurationBarWidth is the widest a bar plus its label can be, so a table can
+// size the column without measuring every row.
+func DurationBarWidth() int {
+	// The label is at most "+59m 59s": one sign, then the longest duration the
+	// bar can meaningfully show before the build is a lost cause anyway.
+	return barCells + 1 + len("+59m 59s")
+}

--- a/internal/tui/golden_test.go
+++ b/internal/tui/golden_test.go
@@ -167,6 +167,17 @@ func TestGoldenViews(t *testing.T) {
 			},
 		},
 		{
+			// The active-only queue is where the progress bars live: every row
+			// is in flight, so every row has one.
+			name: "deployments-active", width: 160, height: 40,
+			setup: func(m *Model) {
+				m.apps.SetApplications(snapshot.Applications, snapshot.ActiveDeployments, now)
+				m.section = SectionDeployments
+				m.deployments.SetItems(snapshot.RecentDeployments, now)
+				m.deployments.ToggleActiveOnly()
+			},
+		},
+		{
 			name: "instances-wide", width: 160, height: 40,
 			setup: func(m *Model) {
 				m.apps.SetApplications(snapshot.Applications, snapshot.ActiveDeployments, now)

--- a/internal/tui/testdata/deployments-active.golden
+++ b/internal/tui/testdata/deployments-active.golden
@@ -1,0 +1,40 @@
+ COOLDECK  Demo   o connected    DEMO                                                                                            12 apps  |  refreshed just now
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ RESOURCES               │DEPLOYMENTS
+                         │2 shown  ·  2 active  ·  active only  ·  a toggle
+   Applications      12  │
+ > Deployments        2  │  STATUS       APPLICATION                    COMMIT   STARTED    DURATION   PROGRESS          TRIGGER  MESSAGE
+   Instances          1  │──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Diagnostics           │> * Running    resetnak-web                   6c880be  21s ago    21s        #------- ~2m 2s   api      fix: handle empty response fr.
+                         │  . Queued     shredloq                       a5f785b  just now   4s         -------- ~1m 4s   api      refactor: extract deployment .
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  ↑↓  select   enter  open log   a  active filter   c  copy UUID   R  refresh   1  apps   ?  help                                                           1/2

--- a/internal/tui/testdata/deployments-wide.golden
+++ b/internal/tui/testdata/deployments-wide.golden
@@ -5,13 +5,14 @@
    Applications      12  │
  > Deployments       33  │  STATUS       APPLICATION                    COMMIT   STARTED    DURATION   PROGRESS          TRIGGER  MESSAGE
    Instances          1  │──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-   Diagnostics           │> + Finished   stimustop-api                  6b3514c  3m ago     1m 12s                       api      chore(deps): bump base image .
+   Diagnostics           │> * Running    resetnak-web                   6c880be  21s ago    21s        #------- ~2m 2s   api      fix: handle empty response fr.
+                         │  . Queued     shredloq                       a5f785b  just now   4s         -------- ~1m 4s   api      refactor: extract deployment .
+                         │  + Finished   stimustop-api                  6b3514c  3m ago     1m 12s                       api      chore(deps): bump base image .
                          │  + Finished   stimustop-api                  9aa0731  13h 3m ago 1m 13s                       webhook  refactor: extract deployment .
                          │  + Finished   stimustop-api                  83f3008  3d 1h ago  1m 52s                       webhook  fix: handle empty response fr.
                          │  + Finished   stimustop-web                  4392015  3m ago     57s                          api      chore(deps): bump base image .
                          │  + Finished   stimustop-web                  f5ef120  1d 19h ago 1m 21s                       manual   chore(deps): bump base image .
                          │  + Finished   stimustop-web                  ccafa8b  2d 2h ago  1m 37s                       manual   chore(deps): bump base image .
-                         │  * Running    resetnak-web                   6c880be  21s ago    21s        #------- ~2m 2s   api      fix: handle empty response fr.
                          │  x Failed     resetnak-web                   f54ced3  18h ago    1m 31s                       manual   fix: handle empty response fr.
                          │  + Finished   resetnak-web                   0134d36  2d 13h ago 2m 2s                        api      chore(deps): bump base image .
                          │  x Failed     maintenea-worker               73e71c6  2h ago     1m 9s                        manual   fix: correct timezone handlin.
@@ -35,6 +36,5 @@
                          │  + Finished   nosmoko                        a900640  11d ago    1m 52s                       webhook  fix: handle empty response fr.
                          │  + Finished   nosmoko                        35d4a45  13d 17h... 32s                          manual   feat: add weekly summary endp.
                          │  + Finished   nosmoko                        63538d5  15d 2h ago 36s                          manual   fix: correct timezone handlin.
-                         │  . Queued     shredloq                       a5f785b  just now   4s         -------- ~1m 4s   api      refactor: extract deployment .
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   ↑↓  select   enter  open log   a  active filter   c  copy UUID   R  refresh   1  apps   ?  help                                                          1/33

--- a/internal/tui/testdata/deployments-wide.golden
+++ b/internal/tui/testdata/deployments-wide.golden
@@ -3,38 +3,38 @@
  RESOURCES               │DEPLOYMENTS
                          │33 shown  ·  2 active  ·  recent history  ·  a toggle
    Applications      12  │
- > Deployments       33  │  STATUS       APPLICATION                             COMMIT   STARTED    DURATION   TRIGGER  MESSAGE
+ > Deployments       33  │  STATUS       APPLICATION                    COMMIT   STARTED    DURATION   PROGRESS          TRIGGER  MESSAGE
    Instances          1  │──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-   Diagnostics           │> + Finished   stimustop-api                           6b3514c  3m ago     1m 12s     api      chore(deps): bump base image to alpine.
-                         │  + Finished   stimustop-api                           9aa0731  13h 3m ago 1m 13s     webhook  refactor: extract deployment mapper
-                         │  + Finished   stimustop-api                           83f3008  3d 1h ago  1m 52s     webhook  fix: handle empty response from upstrea
-                         │  + Finished   stimustop-web                           4392015  3m ago     57s        api      chore(deps): bump base image to alpine.
-                         │  + Finished   stimustop-web                           f5ef120  1d 19h ago 1m 21s     manual   chore(deps): bump base image to alpine.
-                         │  + Finished   stimustop-web                           ccafa8b  2d 2h ago  1m 37s     manual   chore(deps): bump base image to alpine.
-                         │  * Running    resetnak-web                            6c880be  21s ago    21s        api      fix: handle empty response from upstrea
-                         │  x Failed     resetnak-web                            f54ced3  18h ago    1m 31s     manual   fix: handle empty response from upstrea
-                         │  + Finished   resetnak-web                            0134d36  2d 13h ago 2m 2s      api      chore(deps): bump base image to alpine.
-                         │  x Failed     maintenea-worker                        73e71c6  2h ago     1m 9s      manual   fix: correct timezone handling in repor
-                         │  + Finished   maintenea-worker                        9e42a27  1d 17h ago 28s        webhook  docs: document the new environment var.
-                         │  + Finished   maintenea-worker                        555fb7e  4d 5h ago  1m 46s     webhook  fix: correct timezone handling in repor
-                         │  + Finished   maintenea-api                           2099246  47m ago    1m 43s     manual   docs: document the new environment var.
-                         │  + Finished   maintenea-api                           09d4602  18h 47m... 56s        manual   docs: document the new environment var.
-                         │  + Finished   maintenea-api                           6868979  2d 4h ago  1m 21s     webhook  docs: document the new environment var.
-                         │  + Finished   weektraq-api                            b87b02d  1d 2h ago  1m 39s     manual   ci: run tests on arm64 too
-                         │  + Finished   weektraq-api                            848012c  3d 9h ago  2m 28s     api      docs: document the new environment var.
-                         │  x Failed     weektraq-api                            50a86d8  4d 15h ago 1m 32s     manual   docs: document the new environment var.
-                         │  + Finished   weektraq-web                            c7633a1  1d 2h ago  1m 44s     manual   feat: add weekly summary endpoint
-                         │  + Finished   weektraq-web                            3c74e2d  2d 23h ago 2m 18s     api      feat: add weekly summary endpoint
-                         │  + Finished   weektraq-web                            2ca98cc  4d ago     2m 31s     api      docs: document the new environment var.
-                         │  + Finished   logen-ingest-service-with-a-very-lon... 0327dec  5d ago     2m 18s     webhook  chore(deps): bump base image to alpine.
-                         │  x Failed     logen-ingest-service-with-a-very-lon... aa044e8  5d 8h ago  2m 22s     webhook  docs: document the new environment var.
-                         │  + Finished   logen-ingest-service-with-a-very-lon... 6ad87f2  6d 12h ago 1m 41s     webhook  refactor: extract deployment mapper
-                         │  + Finished   logen-dashboard                         7d1e6e8  1m 30s ago 50s        api      chore(deps): bump base image to alpine.
-                         │  + Finished   logen-dashboard                         cb97e32  10h 1m ago 54s        api      refactor: extract deployment mapper
-                         │  + Finished   logen-dashboard                         dbb3ba7  1d 21h ago 2m 21s     api      fix: handle empty response from upstrea
-                         │  + Finished   nosmoko                                 a900640  11d ago    1m 52s     webhook  fix: handle empty response from upstrea
-                         │  + Finished   nosmoko                                 35d4a45  13d 17h... 32s        manual   feat: add weekly summary endpoint
-                         │  + Finished   nosmoko                                 63538d5  15d 2h ago 36s        manual   fix: correct timezone handling in repor
-                         │  . Queued     shredloq                                a5f785b  just now   4s         api      refactor: extract deployment mapper
+   Diagnostics           │> + Finished   stimustop-api                  6b3514c  3m ago     1m 12s                       api      chore(deps): bump base image .
+                         │  + Finished   stimustop-api                  9aa0731  13h 3m ago 1m 13s                       webhook  refactor: extract deployment .
+                         │  + Finished   stimustop-api                  83f3008  3d 1h ago  1m 52s                       webhook  fix: handle empty response fr.
+                         │  + Finished   stimustop-web                  4392015  3m ago     57s                          api      chore(deps): bump base image .
+                         │  + Finished   stimustop-web                  f5ef120  1d 19h ago 1m 21s                       manual   chore(deps): bump base image .
+                         │  + Finished   stimustop-web                  ccafa8b  2d 2h ago  1m 37s                       manual   chore(deps): bump base image .
+                         │  * Running    resetnak-web                   6c880be  21s ago    21s        #------- ~2m 2s   api      fix: handle empty response fr.
+                         │  x Failed     resetnak-web                   f54ced3  18h ago    1m 31s                       manual   fix: handle empty response fr.
+                         │  + Finished   resetnak-web                   0134d36  2d 13h ago 2m 2s                        api      chore(deps): bump base image .
+                         │  x Failed     maintenea-worker               73e71c6  2h ago     1m 9s                        manual   fix: correct timezone handlin.
+                         │  + Finished   maintenea-worker               9e42a27  1d 17h ago 28s                          webhook  docs: document the new enviro.
+                         │  + Finished   maintenea-worker               555fb7e  4d 5h ago  1m 46s                       webhook  fix: correct timezone handlin.
+                         │  + Finished   maintenea-api                  2099246  47m ago    1m 43s                       manual   docs: document the new enviro.
+                         │  + Finished   maintenea-api                  09d4602  18h 47m... 56s                          manual   docs: document the new enviro.
+                         │  + Finished   maintenea-api                  6868979  2d 4h ago  1m 21s                       webhook  docs: document the new enviro.
+                         │  + Finished   weektraq-api                   b87b02d  1d 2h ago  1m 39s                       manual   ci: run tests on arm64 too
+                         │  + Finished   weektraq-api                   848012c  3d 9h ago  2m 28s                       api      docs: document the new enviro.
+                         │  x Failed     weektraq-api                   50a86d8  4d 15h ago 1m 32s                       manual   docs: document the new enviro.
+                         │  + Finished   weektraq-web                   c7633a1  1d 2h ago  1m 44s                       manual   feat: add weekly summary endp.
+                         │  + Finished   weektraq-web                   3c74e2d  2d 23h ago 2m 18s                       api      feat: add weekly summary endp.
+                         │  + Finished   weektraq-web                   2ca98cc  4d ago     2m 31s                       api      docs: document the new enviro.
+                         │  + Finished   logen-ingest-service-with-a... 0327dec  5d ago     2m 18s                       webhook  chore(deps): bump base image .
+                         │  x Failed     logen-ingest-service-with-a... aa044e8  5d 8h ago  2m 22s                       webhook  docs: document the new enviro.
+                         │  + Finished   logen-ingest-service-with-a... 6ad87f2  6d 12h ago 1m 41s                       webhook  refactor: extract deployment .
+                         │  + Finished   logen-dashboard                7d1e6e8  1m 30s ago 50s                          api      chore(deps): bump base image .
+                         │  + Finished   logen-dashboard                cb97e32  10h 1m ago 54s                          api      refactor: extract deployment .
+                         │  + Finished   logen-dashboard                dbb3ba7  1d 21h ago 2m 21s                       api      fix: handle empty response fr.
+                         │  + Finished   nosmoko                        a900640  11d ago    1m 52s                       webhook  fix: handle empty response fr.
+                         │  + Finished   nosmoko                        35d4a45  13d 17h... 32s                          manual   feat: add weekly summary endp.
+                         │  + Finished   nosmoko                        63538d5  15d 2h ago 36s                          manual   fix: correct timezone handlin.
+                         │  . Queued     shredloq                       a5f785b  just now   4s         -------- ~1m 4s   api      refactor: extract deployment .
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   ↑↓  select   enter  open log   a  active filter   c  copy UUID   R  refresh   1  apps   ?  help                                                          1/33

--- a/internal/tui/theme/symbols.go
+++ b/internal/tui/theme/symbols.go
@@ -21,6 +21,8 @@ type SymbolSet struct {
 	Error   string
 	Info    string
 
+	BarFull    string
+	BarEmpty   string
 	Bullet     string
 	ArrowRight string
 	ArrowUp    string
@@ -54,6 +56,8 @@ var UnicodeSymbols = SymbolSet{
 	Error:   "×",
 	Info:    "·",
 
+	BarFull:    "█",
+	BarEmpty:   "░",
 	Bullet:     "•",
 	ArrowRight: "→",
 	ArrowUp:    "↑",
@@ -87,6 +91,8 @@ var ASCIISymbols = SymbolSet{
 	Error:   "x",
 	Info:    "-",
 
+	BarFull:    "#",
+	BarEmpty:   "-",
 	Bullet:     "*",
 	ArrowRight: "->",
 	ArrowUp:    "^",

--- a/internal/tui/views/deployments.go
+++ b/internal/tui/views/deployments.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"slices"
 	"strconv"
 	"time"
 
@@ -33,6 +34,12 @@ func (v *Deployments) SetItems(items []domain.Deployment, at time.Time) {
 		keep = d.UUID
 	}
 	v.items = append([]domain.Deployment{}, items...)
+	// A queue leads with what is happening now. Coolify returns newest first,
+	// which buries an in-flight build under yesterday's history the moment the
+	// history is longer than the screen - and that build is the row the user
+	// opened this section to look at. Sorting here rather than in visible()
+	// means it costs one pass per refresh instead of one per frame.
+	slices.SortStableFunc(v.items, activeFirst)
 	v.loaded = true
 	v.loadedAt = at
 	v.selected = 0

--- a/internal/tui/views/deployments.go
+++ b/internal/tui/views/deployments.go
@@ -153,21 +153,32 @@ func (v *Deployments) Render(th *theme.Theme, width, height int, focused bool, n
 		)
 	}
 
+	// The baseline is taken from the whole loaded history, not just the visible
+	// rows, so filtering to active-only does not remove the very deployments the
+	// expectation is computed from.
+	showProgress := anyDeploymentActive(visible)
+
 	rows := make([]components.Row, 0, len(visible))
 	for _, d := range visible {
 		name := d.ApplicationName
 		if name == "" {
 			name = d.ApplicationUUID
 		}
-		rows = append(rows, components.Row{Cells: []string{
+		cells := []string{
 			th.DeploymentStatusText(d.Status),
 			components.OrDash(name),
 			components.OrDash(d.ShortCommit()),
 			domain.HumanizeAge(d.CreatedAt, now),
 			domain.HumanizeDuration(d.Duration(now)),
+		}
+		if showProgress {
+			cells = append(cells, deploymentProgressCell(th, d, v.items, now))
+		}
+		cells = append(cells,
 			components.OrDash(d.Trigger),
 			components.OrDash(d.CommitMessage),
-		}})
+		)
+		rows = append(rows, components.Row{Cells: cells})
 	}
 
 	header := th.Title.Render("DEPLOYMENTS")
@@ -177,16 +188,23 @@ func (v *Deployments) Render(th *theme.Theme, width, height int, focused bool, n
 	}
 	meta := th.Subtle.Render(strconv.Itoa(len(visible)) + " shown  ·  " +
 		strconv.Itoa(v.ActiveCount()) + " active  ·  " + mode + "  ·  a toggle")
+	columns := []components.Column{
+		{Title: "Status", MinWidth: 12, Priority: 0},
+		{Title: "Application", MinWidth: 14, Flex: 1, Priority: 0},
+		{Title: "Commit", MinWidth: 8, Priority: 1},
+		{Title: "Started", MinWidth: 10, Priority: 2},
+		{Title: "Duration", MinWidth: 10, Priority: 2},
+	}
+	if showProgress {
+		columns = append(columns, progressColumn)
+	}
+	columns = append(columns,
+		components.Column{Title: "Trigger", MinWidth: 8, Priority: 3},
+		components.Column{Title: "Message", MinWidth: 16, Flex: 1, Priority: 4},
+	)
+
 	table := components.Table{
-		Columns: []components.Column{
-			{Title: "Status", MinWidth: 12, Priority: 0},
-			{Title: "Application", MinWidth: 14, Flex: 1, Priority: 0},
-			{Title: "Commit", MinWidth: 8, Priority: 1},
-			{Title: "Started", MinWidth: 10, Priority: 2},
-			{Title: "Duration", MinWidth: 10, Priority: 2},
-			{Title: "Trigger", MinWidth: 8, Priority: 3},
-			{Title: "Message", MinWidth: 16, Flex: 1, Priority: 4},
-		},
+		Columns:  columns,
 		Rows:     rows,
 		Selected: v.selected,
 		Focused:  focused,

--- a/internal/tui/views/deployments_test.go
+++ b/internal/tui/views/deployments_test.go
@@ -1,0 +1,71 @@
+package views
+
+import (
+	"testing"
+	"time"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+)
+
+func deployment(uuid string, status domain.DeploymentStatus) domain.Deployment {
+	return domain.Deployment{UUID: uuid, ApplicationUUID: "app", Status: status}
+}
+
+func uuids(deployments []domain.Deployment) []string {
+	out := make([]string, 0, len(deployments))
+	for _, d := range deployments {
+		out = append(out, d.UUID)
+	}
+	return out
+}
+
+func TestSetItemsLeadsWithWhatIsInFlight(t *testing.T) {
+	view := NewDeployments()
+	now := time.Now()
+
+	// Coolify returns newest first, which puts a running build below a wall of
+	// finished ones as soon as the history is longer than the screen.
+	view.SetItems([]domain.Deployment{
+		deployment("finished-1", domain.DeploymentFinished),
+		deployment("finished-2", domain.DeploymentFailed),
+		deployment("running", domain.DeploymentInProgress),
+		deployment("finished-3", domain.DeploymentFinished),
+		deployment("queued", domain.DeploymentQueued),
+	}, now)
+
+	got := uuids(view.items)
+	want := []string{"running", "queued", "finished-1", "finished-2", "finished-3"}
+	for i := range want {
+		if got[i] != want[i] {
+			// Settled deployments must keep the order they arrived in: the sort
+			// promotes the live ones, it does not reshuffle the history.
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestSelectionFollowsADeploymentThatSettles(t *testing.T) {
+	view := NewDeployments()
+	now := time.Now()
+
+	view.SetItems([]domain.Deployment{
+		deployment("older", domain.DeploymentFinished),
+		deployment("watched", domain.DeploymentInProgress),
+	}, now)
+	if selected, _ := view.Selected(); selected.UUID != "watched" {
+		// It sorted to the top, and the cursor starts at the top.
+		t.Fatalf("selected %q at the top of the queue, want watched", selected.UUID)
+	}
+
+	// The build finishes: it drops back into chronological order, and the
+	// cursor has to follow the row rather than stay on the index.
+	view.SetItems([]domain.Deployment{
+		deployment("older", domain.DeploymentFinished),
+		deployment("watched", domain.DeploymentFinished),
+	}, now)
+
+	selected, ok := view.Selected()
+	if !ok || selected.UUID != "watched" {
+		t.Fatalf("selection = %q (ok=%v), want watched", selected.UUID, ok)
+	}
+}

--- a/internal/tui/views/detail.go
+++ b/internal/tui/views/detail.go
@@ -388,26 +388,42 @@ func (v *Detail) renderDeployments(th *theme.Theme, width, height int, now time.
 		)
 	}
 
+	showProgress := anyDeploymentActive(v.deployments)
+
 	rows := make([]components.Row, 0, len(v.deployments))
 	for _, deployment := range v.deployments {
-		rows = append(rows, components.Row{Cells: []string{
+		cells := []string{
 			th.DeploymentStatusText(deployment.Status),
 			components.OrDash(deployment.ShortCommit()),
 			domain.HumanizeAge(deployment.CreatedAt, now),
 			domain.HumanizeDuration(deployment.Duration(now)),
+		}
+		if showProgress {
+			cells = append(cells, deploymentProgressCell(th, deployment, v.deployments, now))
+		}
+		cells = append(cells,
 			components.OrDash(deployment.Trigger),
 			components.OrDash(deployment.CommitMessage),
-		}})
+		)
+		rows = append(rows, components.Row{Cells: cells})
 	}
+
+	columns := []components.Column{
+		{Title: "Status", MinWidth: 12, Priority: 0},
+		{Title: "Commit", MinWidth: 8, Priority: 0},
+		{Title: "Started", MinWidth: 10, Priority: 1},
+		{Title: "Duration", MinWidth: 10, Priority: 2},
+	}
+	if showProgress {
+		columns = append(columns, progressColumn)
+	}
+	columns = append(columns,
+		components.Column{Title: "Trigger", MinWidth: 8, Priority: 3},
+		components.Column{Title: "Message", MinWidth: 18, Flex: 1, Priority: 4},
+	)
+
 	table := components.Table{
-		Columns: []components.Column{
-			{Title: "Status", MinWidth: 12, Priority: 0},
-			{Title: "Commit", MinWidth: 8, Priority: 0},
-			{Title: "Started", MinWidth: 10, Priority: 1},
-			{Title: "Duration", MinWidth: 10, Priority: 2},
-			{Title: "Trigger", MinWidth: 8, Priority: 3},
-			{Title: "Message", MinWidth: 18, Flex: 1, Priority: 4},
-		},
+		Columns:  columns,
 		Rows:     rows,
 		Selected: v.deploymentSelected,
 		Focused:  true,

--- a/internal/tui/views/progress.go
+++ b/internal/tui/views/progress.go
@@ -1,0 +1,52 @@
+package views
+
+import (
+	"time"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+	"github.com/resetnak/cooldeck/internal/tui/theme"
+)
+
+// baselineSample is how many finished deployments the expected duration is
+// taken from. Five is a compromise: enough that one slow build does not move
+// the median, few enough that the estimate follows a project that genuinely
+// grows heavier over time.
+const baselineSample = 5
+
+// progressColumn is the table column the bar lives in. It is only added when
+// something is actually in flight - a column that is blank on every row is
+// wasted width, and reserving space for content that is not there is a mistake
+// this codebase has already made once.
+var progressColumn = components.Column{
+	Title:      "Progress",
+	ShortTitle: "Prog",
+	MinWidth:   components.DurationBarWidth(),
+	Priority:   2,
+}
+
+// anyDeploymentActive reports whether the Progress column would carry anything.
+func anyDeploymentActive(deployments []domain.Deployment) bool {
+	for _, d := range deployments {
+		if d.Status.IsActive() {
+			return true
+		}
+	}
+	return false
+}
+
+// deploymentProgressCell renders one Progress cell. history is the deployment
+// list the baseline is taken from; it may be a single application's history or
+// a mixed list, since BaselineDuration filters by application.
+func deploymentProgressCell(
+	th *theme.Theme,
+	deployment domain.Deployment,
+	history []domain.Deployment,
+	now time.Time,
+) string {
+	if !deployment.Status.IsActive() {
+		return ""
+	}
+	baseline := domain.BaselineDuration(history, deployment.ApplicationUUID, baselineSample)
+	return components.DurationBar(th, deployment.Duration(now), baseline)
+}

--- a/internal/tui/views/progress.go
+++ b/internal/tui/views/progress.go
@@ -25,6 +25,20 @@ var progressColumn = components.Column{
 	Priority:   2,
 }
 
+// activeFirst orders in-flight deployments ahead of settled ones. It is only
+// ever used with a stable sort, so everything else keeps the order Coolify
+// returned it in - newest first.
+func activeFirst(a, b domain.Deployment) int {
+	switch {
+	case a.Status.IsActive() == b.Status.IsActive():
+		return 0
+	case a.Status.IsActive():
+		return -1
+	default:
+		return 1
+	}
+}
+
 // anyDeploymentActive reports whether the Progress column would carry anything.
 func anyDeploymentActive(deployments []domain.Deployment) bool {
 	for _, d := range deployments {

--- a/internal/tui/views/progress_test.go
+++ b/internal/tui/views/progress_test.go
@@ -1,0 +1,125 @@
+package views
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/theme"
+)
+
+func progressTheme(t *testing.T) *theme.Theme {
+	t.Helper()
+	// ASCII keeps the assertions readable and is the harder case: the bar has
+	// to work for anyone whose terminal mangles block characters.
+	return theme.New(theme.Options{Mode: theme.ModeDark, ASCII: true})
+}
+
+func history(app string, runs ...time.Duration) []domain.Deployment {
+	out := make([]domain.Deployment, 0, len(runs))
+	for i, run := range runs {
+		start := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).Add(-time.Duration(i+1) * time.Hour)
+		end := start.Add(run)
+		out = append(out, domain.Deployment{
+			ApplicationUUID: app,
+			Status:          domain.DeploymentFinished,
+			StartedAt:       start,
+			FinishedAt:      &end,
+		})
+	}
+	return out
+}
+
+func TestProgressCellTracksElapsedAgainstTheBaseline(t *testing.T) {
+	th := progressTheme(t)
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	past := history("app", 100*time.Second, 100*time.Second, 100*time.Second)
+
+	cases := []struct {
+		name    string
+		elapsed time.Duration
+		want    string
+	}{
+		{"just started", 1 * time.Second, "-------- ~1m 40s"},
+		{"half way", 50 * time.Second, "####---- ~1m 40s"},
+		// The bar must not read as full until the build genuinely passes the
+		// expectation, or "full" stops meaning anything.
+		{"nearly there", 99 * time.Second, "#######- ~1m 40s"},
+		{"over budget", 130 * time.Second, "######## +30s"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			running := domain.Deployment{
+				ApplicationUUID: "app",
+				Status:          domain.DeploymentInProgress,
+				StartedAt:       now.Add(-tc.elapsed),
+			}
+
+			got := ansi.Strip(deploymentProgressCell(th, running, past, now))
+			if got != tc.want {
+				t.Fatalf("cell = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProgressCellIsEmptyWhenThereIsNothingHonestToShow(t *testing.T) {
+	th := progressTheme(t)
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+
+	running := domain.Deployment{
+		ApplicationUUID: "app",
+		Status:          domain.DeploymentInProgress,
+		StartedAt:       now.Add(-time.Minute),
+	}
+	finishedRun := domain.Deployment{
+		ApplicationUUID: "app",
+		Status:          domain.DeploymentFinished,
+		StartedAt:       now.Add(-time.Minute),
+	}
+
+	// A first-ever deploy has no expectation to compare against. Inventing one
+	// would be worse than showing nothing.
+	if cell := deploymentProgressCell(th, running, nil, now); cell != "" {
+		t.Errorf("cell without history = %q, want empty", cell)
+	}
+	// A finished deployment's duration is already in the Duration column.
+	if cell := deploymentProgressCell(th, finishedRun, history("app", time.Minute), now); cell != "" {
+		t.Errorf("cell for a finished deployment = %q, want empty", cell)
+	}
+}
+
+func TestProgressColumnFitsItsWidestCell(t *testing.T) {
+	th := progressTheme(t)
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+
+	running := domain.Deployment{
+		ApplicationUUID: "app",
+		Status:          domain.DeploymentInProgress,
+		// Far enough over that the "+" label is at its longest.
+		StartedAt: now.Add(-90 * time.Minute),
+	}
+	cell := ansi.Strip(deploymentProgressCell(th, running, history("app", 30*time.Minute), now))
+
+	// A cell wider than the column would be truncated with an ellipsis, which
+	// would eat the very number the user is looking at.
+	if len(cell) > progressColumn.MinWidth {
+		t.Fatalf("cell %q is %d wide, column is %d", cell, len(cell), progressColumn.MinWidth)
+	}
+	if !strings.HasPrefix(cell, strings.Repeat(th.Sym.BarFull, 8)) {
+		t.Fatalf("an overrun should render a full bar, got %q", cell)
+	}
+}
+
+func TestActiveDetection(t *testing.T) {
+	if anyDeploymentActive(history("app", time.Minute)) {
+		t.Error("finished deployments must not add the Progress column")
+	}
+	if !anyDeploymentActive([]domain.Deployment{{Status: domain.DeploymentQueued}}) {
+		t.Error("a queued deployment is in flight")
+	}
+}


### PR DESCRIPTION
Watching a deploy is the one moment in cooldeck where the user has nothing to do but wait — and the one place the dashboard showed a number without the context to read it. `1m 12s` is good news for an application that builds in two minutes and alarming for one that normally takes forty seconds. Users were answering that from memory, or by eyeballing the history two rows down.

```
> * Running    resetnak-web    6c880be   21s ago    21s    #------- ~2m 2s    api      fix: handle empty response …
  . Queued     shredloq        a5f785b   just now   4s     -------- ~1m 4s    api      refactor: extract deployment …
  + Finished   stimustop-api   6b3514c   3m ago     1m 12s                    api      chore(deps): bump base image …
```

*(ASCII rendering, from the new golden. With block glyphs it reads `█░░░░░░░ ~2m 2s`.)*

Once the build passes the expectation, the bar fills and switches from estimating to reporting the overrun — `████████ +71s` in the attention colour. That transition is the actual product: it is the point at which the user should stop waiting and go read the logs.

The second commit makes the queue lead with what is in flight. Coolify returns deployments newest first, which buried a running build under yesterday's history as soon as that history was longer than the screen — the active-only filter (`a`) existed to work around exactly that. The sort is stable and keys only on whether a deployment is live, so settled ones keep the order they arrived in, and it runs once per refresh rather than once per frame.

## Design constraints worth stating

**No percentage, ever.** Coolify cannot say how far a build has actually got. `60%` would be a claim the UI has no way to back up, and the first slow build would expose it as a lie. What is shown is elapsed against an expectation, with a `~` on the estimate.

**Only successes feed the median.** A build that died after ten seconds says nothing about how long a working one takes; counting failures and cancellations would drag the baseline down and make every normal build look overdue.

**Median of five**, not a mean: one cold-cache or slow-registry outlier should not move the number a user is shown, while five still follows a project that genuinely grows heavier over time.

**No baseline, no bar.** A first-ever deploy shows an empty cell rather than an invented expectation.

**The column only exists when something is in flight.** Reserving width for content that is not there is a mistake this repo has already made once (#2), so `progressColumn` is appended conditionally rather than always present.

## Cost

No new `Service` method, no new request, no new colour — the deployment history was already in the model on both screens, and the bar reuses `Accent`/`Attention`/`Subtle`, which the WCAG AA palette test already covers. Animation is free: `frameInterval` already ticks at 500ms for relative times.

New glyphs `BarFull`/`BarEmpty` are defined in both the Unicode and ASCII symbol sets, so the feature works on a terminal that mangles block characters.

## Testing

`internal/domain/baseline_test.go` covers the median itself: newest-first selection regardless of input order, other applications excluded, failures and cancellations excluded, the even-count middle pair averaged, zero without usable history, and — the subtle one — that a historical run's duration does not drift with the wall clock (`Duration()` measures an unfinished deployment against *now*, so a finished one has to be measured against its own end).

`internal/tui/views/progress_test.go` covers the rendering: the bar at four points including "nearly there" (must not read as full until it genuinely is), the empty cases, and that the widest possible cell still fits the column — a cell wider than its column gets truncated with an ellipsis, which would eat the very number the user is looking at.

`internal/tui/views/deployments_test.go` covers the ordering: live deployments promoted, settled ones keeping their relative order, and the selection following a deployment by UUID as it settles and drops back into chronological position.

New golden `deployments-active` captures the queue with bars on every row; `deployments-wide` now shows the live rows at the top. `make check` and `staticcheck` clean.

## Known limit

A **queued** deployment's elapsed time is measured from queue entry while the baseline is measured from build start, so its bar over-reads slightly until the build begins. Queue time is normally seconds, and it self-corrects.

https://claude.ai/code/session_01YU2MN5vUbJkE3v9j2sVuvn