### PR TITLE
Prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/) once tagged
 releases begin.
 
-## [Unreleased]
+## [0.1.0] - 2026-08-05
 
 ### Added
 
@@ -35,3 +35,5 @@ releases begin.
 - Log sanitisation for ANSI and control characters
 - Tokens excluded from logs, toasts, and diagnostics
 - Browser open restricted to http(s) URLs
+
+[0.1.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.0

--- a/README.cs.md
+++ b/README.cs.md
@@ -17,7 +17,7 @@ z terminálu, který stejně máte otevřený.
 [![Licence: MIT](https://img.shields.io/badge/Licence-MIT-green.svg)](LICENSE)
 [![Platformy](https://img.shields.io/badge/testov%C3%A1no-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-yellow)](.github/workflows/ci.yml)
 [![Coolify API](https://img.shields.io/badge/Coolify-API%20v1-8B5CF6)](docs/coolify-api.md)
-[![Stav](https://img.shields.io/badge/stav-pre--release-orange)](CHANGELOG.md)
+[![Release](https://img.shields.io/github/v/release/Resetnak/cooldeck?color=brightgreen)](https://github.com/Resetnak/cooldeck/releases/latest)
 
 <br>
 
@@ -33,7 +33,7 @@ z terminálu, který stejně máte otevřený.
   <sub>Jedna degradovaná aplikace od začátku do konce: <code>/</code> filtr, <code>enter</code> detail, <code>l</code> runtime logy, <code>d</code> redeploy s potvrzením, <code>2</code> <code>a</code> a je vidět v aktivní frontě. Vyrenderováno z <a href="cassette.tape">cassette.tape</a>.</sub>
 </div>
 
-> ⚠️ **Pre-release.** Zatím neexistuje otagovaný release - build ze zdrojáků je na jeden příkaz. Jednotkové a golden testy běží v CI na Linuxu, macOS i Windows; `--demo` nepotřebuje žádnou instanci Coolify, takže si celé UI můžete prohlédnout dřív, než mu dáte token.
+> **v0.1.0 je venku.** Stáhněte si binárku z [Releases](https://github.com/Resetnak/cooldeck/releases/latest), nebo si ji sestavte ze zdrojáků jedním příkazem. Jednotkové a golden testy běží v CI na Linuxu, macOS i Windows; `--demo` nepotřebuje žádnou instanci Coolify, takže si celé UI můžete prohlédnout dřív, než mu dáte token.
 
 ---
 
@@ -230,9 +230,24 @@ go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
 
 ### Varianta 3: Release binárky
 
+Stáhněte si archiv pro svou platformu z [Releases](https://github.com/Resetnak/cooldeck/releases/latest),
+rozbalte ho a dejte `cooldeck` do `PATH`:
+
+```bash
+tar xzf cooldeck_0.1.0_Darwin_arm64.tar.gz     # nebo Linux_x86_64, Linux_arm64, Darwin_x86_64
+sudo mv cooldeck /usr/local/bin/
+cooldeck version
+```
+
+Windows se distribuuje jako `.zip`. Ke každému vydání patří `checksums.txt`; ověřte si ho, než
+binárce začnete věřit:
+
+```bash
+shasum -a 256 -c checksums.txt --ignore-missing
+```
+
 Archivy pro Linux, macOS a Windows (`amd64` & `arm64`) staví [GoReleaser](.goreleaser.yaml) z tagů
-`v*`, včetně `checksums.txt`. Zatím není vypuštěný žádný tag, takže dnes není co stahovat - sledujte
-[Releases](https://github.com/Resetnak/cooldeck/releases).
+`v*`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ from the terminal you already have open.
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Platforms](https://img.shields.io/badge/tested-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-yellow)](.github/workflows/ci.yml)
 [![Coolify API](https://img.shields.io/badge/Coolify-API%20v1-8B5CF6)](docs/coolify-api.md)
-[![Status](https://img.shields.io/badge/status-pre--release-orange)](CHANGELOG.md)
+[![Release](https://img.shields.io/github/v/release/Resetnak/cooldeck?color=brightgreen)](https://github.com/Resetnak/cooldeck/releases/latest)
 
 <br>
 
@@ -33,7 +33,7 @@ from the terminal you already have open.
   <sub>One degraded app, start to finish: <code>/</code> to filter, <code>enter</code> for the detail, <code>l</code> for runtime logs, <code>d</code> to redeploy behind a confirmation, <code>2</code> <code>a</code> to watch it land in the active queue. Rendered from <a href="cassette.tape">cassette.tape</a>.</sub>
 </div>
 
-> ⚠️ **Pre-release.** There is no tagged release yet - build from source (it takes one command). Unit and golden tests run on Linux, macOS and Windows in CI; `--demo` needs no Coolify instance at all, so you can judge the whole UI before you hand it a token.
+> **v0.1.0 is out.** Grab a binary from [Releases](https://github.com/Resetnak/cooldeck/releases/latest), or build from source in one command. Unit and golden tests run on Linux, macOS and Windows in CI; `--demo` needs no Coolify instance at all, so you can judge the whole UI before you hand it a token.
 
 ---
 
@@ -230,9 +230,23 @@ go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
 
 ### Option 3: Release binaries
 
-Release archives for Linux, macOS and Windows (`amd64` & `arm64`) are produced by
-[GoReleaser](.goreleaser.yaml) from `v*` tags, with a `checksums.txt` alongside them. No tag has been
-pushed yet, so there is nothing to download today - watch [Releases](https://github.com/Resetnak/cooldeck/releases).
+Download an archive for your platform from [Releases](https://github.com/Resetnak/cooldeck/releases/latest),
+unpack it, and put `cooldeck` on your `PATH`:
+
+```bash
+tar xzf cooldeck_0.1.0_Darwin_arm64.tar.gz     # or Linux_x86_64, Linux_arm64, Darwin_x86_64
+sudo mv cooldeck /usr/local/bin/
+cooldeck version
+```
+
+Windows ships as a `.zip`. Every release carries a `checksums.txt`; verify before you trust it:
+
+```bash
+shasum -a 256 -c checksums.txt --ignore-missing
+```
+
+Archives for Linux, macOS and Windows (`amd64` & `arm64`) are built by
+[GoReleaser](.goreleaser.yaml) from `v*` tags.
 
 ---
 


### PR DESCRIPTION
Changelog's `Unreleased` becomes `0.1.0`, the pre-release badge becomes a live release badge, and both install sections stop saying there is nothing to download.

The install instructions now include verifying `checksums.txt` - the step people skip when the README does not spell it out.

Merging this unblocks the `v0.1.0` tag.

https://claude.ai/code/session_01YU2MN5vUbJkE3v9j2sVuvn