### PR TITLE
Publish a Homebrew cask on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Publishing the Homebrew cask writes to Resetnak/homebrew-tap, which
+          # the workflow's own GITHUB_TOKEN cannot reach: it is scoped to this
+          # repository. A fine-grained PAT limited to the tap fills the gap.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,3 +51,26 @@ changelog:
 release:
   draft: false
   prerelease: auto
+
+# Homebrew: a cask rather than a formula, because what ships here is a
+# pre-built binary, not something Homebrew compiles. Pushing to the tap needs a
+# token that can write to another repository, which the workflow's own
+# GITHUB_TOKEN cannot - hence HOMEBREW_TAP_GITHUB_TOKEN.
+homebrew_casks:
+  - name: cooldeck
+    repository:
+      owner: Resetnak
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/Resetnak/cooldeck
+    description: Keyboard-first terminal dashboard for Coolify
+    # Strip the quarantine flag Gatekeeper adds to downloaded archives, so the
+    # first run does not die with "cannot be opened because the developer
+    # cannot be verified".
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cooldeck"]
+          end

--- a/README.cs.md
+++ b/README.cs.md
@@ -202,33 +202,19 @@ Kompletní mapa: v aplikaci `?`, nebo [docs/keybindings.md](docs/keybindings.md)
 
 ## 📦 Instalace
 
-**Požadavek:** Go **1.26.5+** pro build. Bez CGO, bez runtime závislostí - výsledkem je jedna statická
-binárka.
+**Žádné runtime závislosti.** Každá varianta níž vám dá jednu statickou binárku; toolchain
+potřebuje jen build ze zdrojáků (Go **1.26.5+**, bez CGO).
 
-### Varianta 1: Build ze zdrojáků (zatím ta správná cesta)
-
-```bash
-git clone https://github.com/Resetnak/cooldeck.git
-cd cooldeck
-make build          # -> bin/cooldeck, s vloženou verzí/commitem/datem
-./bin/cooldeck --demo
-```
-
-Pak si ji dejte někam do `PATH`:
+### Varianta 1: Homebrew (macOS a Linux)
 
 ```bash
-install -m 0755 bin/cooldeck ~/.local/bin/cooldeck    # macOS / Linux
+brew install resetnak/tap/cooldeck
+cooldeck --demo
 ```
 
-### Varianta 2: `go install`
+Aktualizace pak chodí přes `brew upgrade` jako u čehokoli jiného.
 
-```bash
-go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
-```
-
-> ℹ️ Bude fungovat, jakmile bude repozitář veřejný; do té doby použijte variantu 1.
-
-### Varianta 3: Release binárky
+### Varianta 2: Release binárky
 
 Stáhněte si archiv pro svou platformu z [Releases](https://github.com/Resetnak/cooldeck/releases/latest),
 rozbalte ho a dejte `cooldeck` do `PATH`:
@@ -248,6 +234,22 @@ shasum -a 256 -c checksums.txt --ignore-missing
 
 Archivy pro Linux, macOS a Windows (`amd64` & `arm64`) staví [GoReleaser](.goreleaser.yaml) z tagů
 `v*`.
+
+### Varianta 3: `go install`
+
+```bash
+go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
+```
+
+### Varianta 4: Build ze zdrojáků
+
+```bash
+git clone https://github.com/Resetnak/cooldeck.git
+cd cooldeck
+make build          # -> bin/cooldeck, s verzí/commitem/datem zabudovaným dovnitř
+./bin/cooldeck --demo
+install -m 0755 bin/cooldeck ~/.local/bin/cooldeck
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -202,33 +202,19 @@ Full map: press `?` in the app, or read [docs/keybindings.md](docs/keybindings.m
 
 ## 📦 Installation
 
-**Requirements:** Go **1.26.5+** to build. No CGO, no runtime dependencies - the result is a single
-static binary.
+**No runtime dependencies.** Every option below leaves you with a single static binary; only building
+from source needs a toolchain (Go **1.26.5+**, no CGO).
 
-### Option 1: Build from source (the way, for now)
-
-```bash
-git clone https://github.com/Resetnak/cooldeck.git
-cd cooldeck
-make build          # -> bin/cooldeck, with version/commit/date baked in
-./bin/cooldeck --demo
-```
-
-Then put it somewhere on your `PATH`:
+### Option 1: Homebrew (macOS & Linux)
 
 ```bash
-install -m 0755 bin/cooldeck ~/.local/bin/cooldeck    # macOS / Linux
+brew install resetnak/tap/cooldeck
+cooldeck --demo
 ```
 
-### Option 2: `go install`
+Upgrades come with `brew upgrade` like anything else.
 
-```bash
-go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
-```
-
-> ℹ️ This works once the repository is public; until then, use Option 1.
-
-### Option 3: Release binaries
+### Option 2: Release binaries
 
 Download an archive for your platform from [Releases](https://github.com/Resetnak/cooldeck/releases/latest),
 unpack it, and put `cooldeck` on your `PATH`:
@@ -247,6 +233,22 @@ shasum -a 256 -c checksums.txt --ignore-missing
 
 Archives for Linux, macOS and Windows (`amd64` & `arm64`) are built by
 [GoReleaser](.goreleaser.yaml) from `v*` tags.
+
+### Option 3: `go install`
+
+```bash
+go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
+```
+
+### Option 4: Build from source
+
+```bash
+git clone https://github.com/Resetnak/cooldeck.git
+cd cooldeck
+make build          # -> bin/cooldeck, with version/commit/date baked in
+./bin/cooldeck --demo
+install -m 0755 bin/cooldeck ~/.local/bin/cooldeck
+```
 
 ---
 


### PR DESCRIPTION
`brew install resetnak/tap/cooldeck` is what people reach for first on macOS, and the only install path that also handles upgrades. [Resetnak/homebrew-tap](https://github.com/Resetnak/homebrew-tap) is created and empty, waiting for the first release to populate it.

A **cask** rather than a formula: what ships is a pre-built binary, not something Homebrew compiles, and goreleaser deprecated the formula path for this case. The postflight hook strips the quarantine attribute Gatekeeper puts on downloaded archives, so the first run does not die with *cannot be opened because the developer cannot be verified*.

Validated with `goreleaser check` and a snapshot run: the generated cask carries per-architecture URLs and checksums for macOS and Linux alike.

**One step is not mine to take.** Publishing writes to the tap repository, which the workflow's own `GITHUB_TOKEN` cannot reach - it is scoped to this repository. The release job therefore reads `HOMEBREW_TAP_GITHUB_TOKEN`, which has to be a fine-grained PAT limited to the tap. I deliberately did not reuse the broadly-scoped token from the local `gh` CLI for that.

Until the secret exists a tag still produces a normal release; only the cask step fails.

https://claude.ai/code/session_01YU2MN5vUbJkE3v9j2sVuvn