### PR TITLE
Prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/) once tagged
 releases begin.
 
+## [0.1.1] - 2026-08-05
+
+Packaging only - the binary is identical to 0.1.0.
+
+### Added
+
+- Homebrew cask: `brew install resetnak/tap/cooldeck`, published automatically on every tag
+
+### Changed
+
+- Install instructions lead with Homebrew rather than cloning the repository
+
 ## [0.1.0] - 2026-08-05
 
 ### Added
@@ -36,4 +48,5 @@ releases begin.
 - Tokens excluded from logs, toasts, and diagnostics
 - Browser open restricted to http(s) URLs
 
+[0.1.1]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.0

--- a/README.cs.md
+++ b/README.cs.md
@@ -220,7 +220,7 @@ Stáhněte si archiv pro svou platformu z [Releases](https://github.com/Resetnak
 rozbalte ho a dejte `cooldeck` do `PATH`:
 
 ```bash
-tar xzf cooldeck_0.1.0_Darwin_arm64.tar.gz     # nebo Linux_x86_64, Linux_arm64, Darwin_x86_64
+tar xzf cooldeck_*_Darwin_arm64.tar.gz     # nebo Linux_x86_64, Linux_arm64, Darwin_x86_64
 sudo mv cooldeck /usr/local/bin/
 cooldeck version
 ```

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Download an archive for your platform from [Releases](https://github.com/Resetna
 unpack it, and put `cooldeck` on your `PATH`:
 
 ```bash
-tar xzf cooldeck_0.1.0_Darwin_arm64.tar.gz     # or Linux_x86_64, Linux_arm64, Darwin_x86_64
+tar xzf cooldeck_*_Darwin_arm64.tar.gz     # or Linux_x86_64, Linux_arm64, Darwin_x86_64
 sudo mv cooldeck /usr/local/bin/
 cooldeck version
 ```


### PR DESCRIPTION
Packaging only - the binary is identical to 0.1.0. Tagging this exercises the Homebrew cask path for the first time now that `HOMEBREW_TAP_GITHUB_TOKEN` exists.

The tar example in both READMEs loses its hardcoded version; it would have gone stale on every release, and a glob copy-pastes just as well.

https://claude.ai/code/session_01YU2MN5vUbJkE3v9j2sVuvn