### PR TITLE
Add Linux packages and a checksum-verifying install script

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,3 +74,26 @@ homebrew_casks:
           if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cooldeck"]
           end
+
+# Linux packages, built from the same binaries as the archives. A server
+# operator who reaches for apt or dnf should not have to unpack a tarball and
+# pick a directory to put it in.
+nfpms:
+  - id: packages
+    package_name: cooldeck
+    vendor: Resetnak
+    homepage: https://github.com/Resetnak/cooldeck
+    maintainer: Alexandr Resetnak <mail@resetnak.cz>
+    description: |-
+      Keyboard-first terminal dashboard for Coolify.
+      Deployments, logs, restarts and instance switching from the terminal.
+    license: MIT
+    formats: [deb, rpm, apk]
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/cooldeck/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/cooldeck/README.md
+      - src: CHANGELOG.md
+        dst: /usr/share/doc/cooldeck/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/) once tagged
 releases begin.
 
+## [0.1.2] - 2026-08-05
+
+Packaging only - the binary is identical to 0.1.0.
+
+### Added
+
+- Linux packages: `.deb`, `.rpm` and `.apk` for amd64 and arm64 on every release
+- `install.sh`: one-line install for macOS and Linux that verifies the checksum before installing
+
 ## [0.1.1] - 2026-08-05
 
 Packaging only - the binary is identical to 0.1.0.
@@ -48,5 +57,6 @@ Packaging only - the binary is identical to 0.1.0.
 - Tokens excluded from logs, toasts, and diagnostics
 - Browser open restricted to http(s) URLs
 
+[0.1.2]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.2
 [0.1.1]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.0

--- a/README.cs.md
+++ b/README.cs.md
@@ -214,7 +214,33 @@ cooldeck --demo
 
 Aktualizace pak chodí přes `brew upgrade` jako u čehokoli jiného.
 
-### Varianta 2: Release binárky
+### Varianta 2: Instalační skript (macOS a Linux)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Resetnak/cooldeck/main/install.sh | sh
+```
+
+Rozpozná platformu, **ověří kontrolní součet** a binárku uloží do `~/.local/bin`. Cíl přepíšete přes
+`COOLDECK_INSTALL_DIR`, konkrétní verzi vynutíte přes `COOLDECK_VERSION=v0.1.1`. Jestli se vám nechce
+pouštět skript rovnou do shellu, [přečtěte si ho](install.sh) - je krátký.
+
+### Varianta 3: Linuxové balíčky
+
+```bash
+# Debian / Ubuntu
+curl -fsSLO https://github.com/Resetnak/cooldeck/releases/latest/download/cooldeck_0.1.2_linux_amd64.deb
+sudo dpkg -i cooldeck_0.1.2_linux_amd64.deb
+
+# Fedora / RHEL
+sudo rpm -i https://github.com/Resetnak/cooldeck/releases/latest/download/cooldeck_0.1.2_linux_amd64.rpm
+
+# Alpine
+sudo apk add --allow-untrusted cooldeck_0.1.2_linux_amd64.apk
+```
+
+`.deb`, `.rpm` i `.apk` se staví pro `amd64` a `arm64` při každém vydání.
+
+### Varianta 4: Release binárky
 
 Stáhněte si archiv pro svou platformu z [Releases](https://github.com/Resetnak/cooldeck/releases/latest),
 rozbalte ho a dejte `cooldeck` do `PATH`:
@@ -235,13 +261,13 @@ shasum -a 256 -c checksums.txt --ignore-missing
 Archivy pro Linux, macOS a Windows (`amd64` & `arm64`) staví [GoReleaser](.goreleaser.yaml) z tagů
 `v*`.
 
-### Varianta 3: `go install`
+### Varianta 5: `go install`
 
 ```bash
 go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
 ```
 
-### Varianta 4: Build ze zdrojáků
+### Varianta 6: Build ze zdrojáků
 
 ```bash
 git clone https://github.com/Resetnak/cooldeck.git

--- a/README.md
+++ b/README.md
@@ -214,7 +214,33 @@ cooldeck --demo
 
 Upgrades come with `brew upgrade` like anything else.
 
-### Option 2: Release binaries
+### Option 2: Install script (macOS & Linux)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Resetnak/cooldeck/main/install.sh | sh
+```
+
+Detects your platform, **verifies the checksum**, and drops the binary in `~/.local/bin`. Override
+with `COOLDECK_INSTALL_DIR`, or pin a version with `COOLDECK_VERSION=v0.1.1`. Read it first if you
+would rather not pipe a script into a shell - [it is short](install.sh).
+
+### Option 3: Linux packages
+
+```bash
+# Debian / Ubuntu
+curl -fsSLO https://github.com/Resetnak/cooldeck/releases/latest/download/cooldeck_0.1.2_linux_amd64.deb
+sudo dpkg -i cooldeck_0.1.2_linux_amd64.deb
+
+# Fedora / RHEL
+sudo rpm -i https://github.com/Resetnak/cooldeck/releases/latest/download/cooldeck_0.1.2_linux_amd64.rpm
+
+# Alpine
+sudo apk add --allow-untrusted cooldeck_0.1.2_linux_amd64.apk
+```
+
+`.deb`, `.rpm` and `.apk` are built for `amd64` and `arm64` on every release.
+
+### Option 4: Release binaries
 
 Download an archive for your platform from [Releases](https://github.com/Resetnak/cooldeck/releases/latest),
 unpack it, and put `cooldeck` on your `PATH`:
@@ -234,13 +260,13 @@ shasum -a 256 -c checksums.txt --ignore-missing
 Archives for Linux, macOS and Windows (`amd64` & `arm64`) are built by
 [GoReleaser](.goreleaser.yaml) from `v*` tags.
 
-### Option 3: `go install`
+### Option 5: `go install`
 
 ```bash
 go install github.com/resetnak/cooldeck/cmd/cooldeck@latest
 ```
 
-### Option 4: Build from source
+### Option 6: Build from source
 
 ```bash
 git clone https://github.com/Resetnak/cooldeck.git

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Install the latest cooldeck release.
+#
+#   curl -fsSL https://raw.githubusercontent.com/Resetnak/cooldeck/main/install.sh | sh
+#
+# Reads nothing, writes one binary, and verifies its checksum before doing so.
+# Override the destination with COOLDECK_INSTALL_DIR, or pin a version with
+# COOLDECK_VERSION=v0.1.1.
+#
+# POSIX sh on purpose: this has to run on a stock Alpine container as readily
+# as on a Mac.
+set -eu
+
+REPO="Resetnak/cooldeck"
+INSTALL_DIR="${COOLDECK_INSTALL_DIR:-$HOME/.local/bin}"
+
+fail() {
+	echo "install: $1" >&2
+	exit 1
+}
+
+need() {
+	command -v "$1" >/dev/null 2>&1 || fail "$1 is required but not installed"
+}
+
+need uname
+need tar
+need mktemp
+
+# curl or wget, whichever the machine happens to have.
+if command -v curl >/dev/null 2>&1; then
+	fetch() { curl -fsSL "$1" -o "$2"; }
+	fetch_stdout() { curl -fsSL "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+	fetch() { wget -qO "$2" "$1"; }
+	fetch_stdout() { wget -qO- "$1"; }
+else
+	fail "neither curl nor wget is installed"
+fi
+
+case "$(uname -s)" in
+Linux) os="Linux" ;;
+Darwin) os="Darwin" ;;
+*) fail "unsupported operating system: $(uname -s). Windows users: download the .zip from https://github.com/$REPO/releases/latest" ;;
+esac
+
+case "$(uname -m)" in
+x86_64 | amd64) arch="x86_64" ;;
+arm64 | aarch64) arch="arm64" ;;
+*) fail "unsupported architecture: $(uname -m)" ;;
+esac
+
+version="${COOLDECK_VERSION:-}"
+if [ -z "$version" ]; then
+	# Follow the /latest redirect rather than parsing the API, so this needs no
+	# JSON tooling and no API token.
+	version=$(fetch_stdout "https://github.com/$REPO/releases/latest" 2>/dev/null |
+		sed -n 's|.*/releases/tag/\(v[0-9][^"]*\)".*|\1|p' | head -n 1)
+	[ -n "$version" ] || fail "could not determine the latest version; set COOLDECK_VERSION"
+fi
+
+archive="cooldeck_${version#v}_${os}_${arch}.tar.gz"
+base="https://github.com/$REPO/releases/download/$version"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+echo "install: downloading cooldeck $version for $os/$arch"
+fetch "$base/$archive" "$tmp/$archive" || fail "download failed: $base/$archive"
+fetch "$base/checksums.txt" "$tmp/checksums.txt" || fail "could not download checksums.txt"
+
+# Verify before trusting. A download that cannot be checked is not installed.
+expected=$(grep " $archive\$" "$tmp/checksums.txt" | cut -d' ' -f1)
+[ -n "$expected" ] || fail "$archive is not listed in checksums.txt"
+
+if command -v sha256sum >/dev/null 2>&1; then
+	actual=$(sha256sum "$tmp/$archive" | cut -d' ' -f1)
+elif command -v shasum >/dev/null 2>&1; then
+	actual=$(shasum -a 256 "$tmp/$archive" | cut -d' ' -f1)
+else
+	fail "neither sha256sum nor shasum is installed, so the download cannot be verified"
+fi
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $archive: expected $expected, got $actual"
+
+tar -xzf "$tmp/$archive" -C "$tmp" cooldeck
+mkdir -p "$INSTALL_DIR"
+install -m 0755 "$tmp/cooldeck" "$INSTALL_DIR/cooldeck" 2>/dev/null ||
+	{ cp "$tmp/cooldeck" "$INSTALL_DIR/cooldeck" && chmod 0755 "$INSTALL_DIR/cooldeck"; }
+
+echo "install: cooldeck $version -> $INSTALL_DIR/cooldeck"
+case ":$PATH:" in
+*":$INSTALL_DIR:"*) echo "install: run 'cooldeck --demo' to try it offline" ;;
+*) echo "install: $INSTALL_DIR is not on your PATH; add it, or run $INSTALL_DIR/cooldeck" ;;
+esac


### PR DESCRIPTION
Without Homebrew the only paths were unpacking a tarball by hand or having a Go toolchain - a poor showing for a tool whose natural home is a server.

**Linux packages.** `nfpms` builds `.deb`, `.rpm` and `.apk` from the same binaries as the archives, for amd64 and arm64. Verified from a snapshot build: the binary lands in `/usr/bin`, docs in `/usr/share/doc/cooldeck`, and the control metadata carries the maintainer, homepage and description.

**Install script.** POSIX `sh`, so it runs on a stock Alpine container as readily as on a Mac. It resolves the latest tag by following the `/releases/latest` redirect rather than parsing the API, so it needs no JSON tooling and no token. It **verifies the checksum and refuses to install on a mismatch** - the step most install scripts skip.

Tested against the live v0.1.1 release: latest resolution, `COOLDECK_VERSION` pinning to v0.1.0, a nonexistent version failing cleanly, and - with a deliberately corrupted download - the mismatch path refusing to install anything.

Install docs in both languages now run Homebrew, script, packages, archives, `go install`, source.

https://claude.ai/code/session_01YU2MN5vUbJkE3v9j2sVuvn