### PR TITLE
Tail several applications' logs in one buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/) once tagged
 releases begin.
 
+## [Unreleased]
+
+### Added
+
+- Fleet tail: mark applications with `space`, press `t`, and read their runtime logs interleaved in one buffer
+
 ## [0.1.2] - 2026-08-05
 
 Packaging only - the binary is identical to 0.1.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,9 @@ cmd/cooldeck → internal/cli (cobra, flags, config load, service construction)
              → internal/domain, config, credentials, logging, platform, version
 ```
 
-`docs/architecture.md` has the full picture; `docs/decisions/` holds six ADRs (Go+Charm v2,
-direct REST instead of MCP, domain/DTO split, credential storage, responsive layout, MCP server).
+`docs/architecture.md` has the full picture; `docs/decisions/` holds seven ADRs (Go+Charm v2,
+direct REST instead of MCP, domain/DTO split, credential storage, responsive layout, MCP server,
+fleet-tail concurrency).
 `CLAUDE_CODE_COOLIFY_TUI_SPEC.md` is the original full product spec.
 
 ### Key invariants
@@ -74,6 +75,10 @@ Each request kind (dashboard, detail, runtime logs, deployment logs, connect, op
 cancels the previous one; replies whose seq is stale are dropped. Mutating operations are serialised
 via `operationInFlight`. Failed refreshes keep the last good snapshot on screen plus a stale banner -
 they never wipe the list. Instance switch clears app/detail/deployment caches so fleets cannot mix.
+
+The fleet tail is the one deliberate exception: it runs one request per tailed application at once,
+identified by a single `tailSeq` rather than a cancel function each. Leaving the tail bumps the
+sequence, which orphans every reply still in flight at once (ADR 0007).
 
 `requestTimeout` (20s) bounds every API call; `frameInterval` (500ms) drives spinner and relative times.
 

--- a/README.cs.md
+++ b/README.cs.md
@@ -76,6 +76,7 @@ si přečte konfiguraci, vytáhne token z OS keyringu a vykreslí.
 
 - **🖥️ Celá flotila na jedné obrazovce**: stav, projekt/prostředí, branch, poslední deploy a doména u každé aplikace, s filtrem (`/`) a řazením (`S`).
 - **🔎 Detail bez přepínání kontextu**: přehled, historie deploymentů, runtime logy a konfigurace jako záložky na téže obrazovce.
+- **🛰️ Fleet tail**: označte aplikace klávesou `space`, zmáčkněte `t` a čtěte jejich runtime logy proložené v jednom bufferu, každý řádek pojmenovaný a obarvený podle aplikace - pohled, který vám webové UI Coolify nedá.
 - **📜 Logy, které se dají číst**: follow, pauza, zalamování, hledání v bufferu s `n`/`N`, kopírování nálezu, vyčištění bufferu, `+`/`-` pro rozšíření nebo zúžení okna řádků.
 - **🚀 Operace jen s potvrzením**: deploy, force deploy, restart, start/stop - každá destruktivní akce se nejdřív zeptá a najednou běží vždy jen jedna mutace.
 - **🛟 Poctivé k výpadkům**: neúspěšný refresh nechá na obrazovce poslední dobrá data pod „stale“ bannerem, místo aby seznam vymazal. Viz [Když Coolify zamrká](#-když-coolify-zamrká).
@@ -393,7 +394,7 @@ vypustila ven.
 | Dokument | |
 | :--- | :--- |
 | [Architektura](docs/architecture.md) | Vrstvy, tok zpráv, asynchronní životní cyklus |
-| [Rozhodnutí](docs/decisions/) | Šest ADR: Go + Charm, přímé REST místo MCP, oddělení domény a DTO, ukládání přihlašovacích údajů, responzivní layout, MCP server |
+| [Rozhodnutí](docs/decisions/) | Sedm ADR: Go + Charm, přímé REST místo MCP, oddělení domény a DTO, ukládání přihlašovacích údajů, responzivní layout, MCP server, souběžnost fleet tailu |
 | [Coolify API](docs/coolify-api.md) | Které endpointy se používají a jak |
 | [MCP server](docs/mcp.md) | Připojení agenta: klienti, nástroje, bezpečnost, řešení potíží |
 | [Konfigurace](docs/configuration.md) | Kompletní reference schématu |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ your config, pulls a token out of your OS keyring, and renders.
 
 - **🖥️ The whole fleet on one screen**: status, project/environment, branch, last deploy and domain for every application, with filtering (`/`) and sorting (`S`).
 - **🔎 Detail without a context switch**: overview, deployment history, runtime logs and configuration as tabs on the same screen.
+- **🛰️ Fleet tail**: mark applications with `space`, press `t`, and read their runtime logs interleaved in one buffer, each line named and coloured by the application it came from - the view Coolify's web UI cannot give you.
 - **📜 Real log ergonomics**: follow, pause, wrap, in-buffer search with `n`/`N`, copy the match, clear the buffer, `+`/`-` to widen or narrow the line window.
 - **🚀 Operations behind a confirmation**: deploy, force deploy, restart, start/stop - every destructive action asks first, and only one mutation runs at a time.
 - **🛟 Honest about failure**: a refresh that fails keeps the last good data on screen behind a stale banner instead of blanking the list. See [When Coolify blinks](#-when-coolify-blinks).
@@ -392,7 +393,7 @@ shipping.
 | Doc | |
 | :--- | :--- |
 | [Architecture](docs/architecture.md) | Layers, message flow, async lifecycle |
-| [Decisions](docs/decisions/) | Six ADRs: Go + Charm, direct REST over MCP, domain/DTO split, credential storage, responsive layout, MCP server |
+| [Decisions](docs/decisions/) | Seven ADRs: Go + Charm, direct REST over MCP, domain/DTO split, credential storage, responsive layout, MCP server, fleet-tail concurrency |
 | [Coolify API](docs/coolify-api.md) | Which endpoints are used and how |
 | [MCP server](docs/mcp.md) | Connecting an agent: clients, tools, safety, troubleshooting |
 | [Configuration](docs/configuration.md) | Full schema reference |

--- a/docs/decisions/0007-fleet-tail-concurrency.md
+++ b/docs/decisions/0007-fleet-tail-concurrency.md
@@ -1,0 +1,48 @@
+# 0007. One request per tailed application, bounded by a shared sequence
+
+## Status
+
+Accepted.
+
+## Context
+
+Every other request kind in `internal/tui` keeps exactly one request in flight:
+a sequence number plus a stored `context.CancelFunc` on the `Model`, where a new
+request cancels the previous one and stale replies are dropped by sequence.
+
+The fleet tail breaks that shape by construction. Coolify serves logs as whole
+snapshots rather than a stream, so tailing N applications means N independent
+polls, repeatedly, for as long as the screen is open. A single cancel function
+cannot express that, and one cancel function per application would put an
+unbounded map of them on the `Model`.
+
+Those polls also land on a rate limit that the whole session shares -
+`config.MinRefreshInterval` exists for exactly that reason.
+
+## Decision
+
+- The tail keeps **one sequence number for the whole session**, `tailSeq`, and
+  no cancel functions. Every source's replies carry it; leaving the tail bumps
+  it, which orphans all of them at once.
+- Each request still gets `requestTimeout`, so nothing outlives the screen by
+  more than 20 seconds even though nothing cancels it.
+- **At most `views.MaxTailApps` (5) sources.** The cap is a rate-limit guard
+  first and a readability one second.
+- Polls are **staggered** across the interval rather than fired together, and
+  the tail interval is deliberately slower than the single-application one.
+- A failure degrades **one source**, not the screen. The failing source is
+  labelled in the header and retried with a backoff; a rate limit is obeyed for
+  exactly as long as Coolify asked for.
+
+## Consequences
+
+- The invariant in CLAUDE.md is now "one in flight per request kind, except the
+  fleet tail" rather than an unqualified rule. Stated explicitly so the next
+  reader does not take the exception as licence.
+- Cancellation is coarser: leaving the tail does not abort the HTTP requests
+  already issued, it only ignores their replies. With a 20-second ceiling and at
+  most five of them, that is a bounded cost rather than a leak.
+- Raising the cap means re-examining the rate-limit arithmetic, not just the
+  constant. At five sources on a four-second interval the tail averages a little
+  over one request per second, which is below what the dashboard refresh already
+  costs.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -43,6 +43,8 @@ behaviour, footer hints, and the help overlay together.
 | `b` / `o` | Open primary domain / repository |
 | `c` | Copy application UUID |
 | `S` | Cycle sort (status → name → last deploy) |
+| `space` | Mark / unmark for the fleet tail |
+| `t` | Tail the marked applications |
 | `/` | Filter (`status:`, `project:`, `env:`, `branch:`, free text) |
 
 ## Detail & logs
@@ -67,6 +69,17 @@ behaviour, footer hints, and the help overlay together.
 | `Enter` | Open build log for selected deployment |
 | `a` | Toggle active-only / recent history |
 | `c` | Copy deployment UUID |
+
+## Fleet tail
+
+| Keys | Action |
+|------|--------|
+| `space` | Pause / resume polling |
+| `f` | Follow the newest line |
+| `w` | Wrap long lines |
+| `/` | Search the merged buffer |
+| `c` | Copy the buffer |
+| `esc` / `q` | Back to applications |
 
 ## Instances
 

--- a/internal/tui/golden_test.go
+++ b/internal/tui/golden_test.go
@@ -178,6 +178,30 @@ func TestGoldenViews(t *testing.T) {
 			},
 		},
 		{
+			// Three applications interleaved: the tag colours and the shared
+			// log ergonomics are the whole point of the screen.
+			name: "fleet-tail", width: 160, height: 40,
+			setup: func(m *Model) {
+				m.apps.SetApplications(snapshot.Applications, snapshot.ActiveDeployments, now)
+				for _, uuid := range []string{
+					snapshot.Applications[0].UUID,
+					snapshot.Applications[1].UUID,
+					snapshot.Applications[4].UUID,
+				} {
+					m.apps.SelectUUID(uuid)
+					m.apps.ToggleMark()
+				}
+				m.openTail()
+				for _, a := range m.apps.Marked() {
+					lines, err := service.RuntimeLogs(t.Context(), a.UUID, 6)
+					if err != nil {
+						t.Fatal(err)
+					}
+					m.tail.SetLines(a.UUID, lines.Lines, now)
+				}
+			},
+		},
+		{
 			name: "instances-wide", width: 160, height: 40,
 			setup: func(m *Model) {
 				m.apps.SetApplications(snapshot.Applications, snapshot.ActiveDeployments, now)

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -95,6 +95,19 @@ func (m *Model) helpGroups() []helpGroup {
 				{"b / o", "open domain / repository"},
 				{"c", "copy UUID"},
 				{"S", "cycle sort mode"},
+				{"space", "mark for the fleet tail"},
+				{"t", "tail the marked applications"},
+			},
+		},
+		{
+			Title: "Fleet tail",
+			Rows: []helpRow{
+				{"space", "pause / resume polling"},
+				{"f", "follow the newest line"},
+				{"w", "wrap long lines"},
+				{"/", "search the merged buffer"},
+				{"c", "copy the buffer"},
+				{"esc / q", "back to applications"},
 			},
 		},
 		{

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -32,6 +32,10 @@ type KeyMap struct {
 	Theme   key.Binding
 	Compact key.Binding
 
+	// Fleet tail.
+	Mark key.Binding
+	Tail key.Binding
+
 	// Sections.
 	SectionApplications key.Binding
 	SectionDeployments  key.Binding
@@ -96,6 +100,9 @@ func DefaultKeyMap() KeyMap {
 		Refresh: key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refresh")),
 		Theme:   key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("ctrl+t", "toggle theme")),
 		Compact: key.NewBinding(key.WithKeys("ctrl+w"), key.WithHelp("ctrl+w", "compact mode")),
+
+		Mark: key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "mark for tail")),
+		Tail: key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tail marked")),
 
 		SectionApplications: key.NewBinding(key.WithKeys("1"), key.WithHelp("1", "applications")),
 		SectionDeployments:  key.NewBinding(key.WithKeys("2"), key.WithHelp("2", "deployments")),

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -79,6 +79,26 @@ type actionFailedMsg struct {
 	Err *domain.Error
 }
 
+// tailTickMsg schedules one fleet-tail source. Unlike the other request kinds
+// several are in flight at once, so the sequence number is what tells a live
+// reply from one that belongs to a tail the user has already left.
+type tailTickMsg struct {
+	Seq     uint64
+	AppUUID string
+}
+
+type tailLoadedMsg struct {
+	Seq      uint64
+	AppUUID  string
+	Snapshot app.LogSnapshot
+}
+
+type tailFailedMsg struct {
+	Seq     uint64
+	AppUUID string
+	Err     *domain.Error
+}
+
 type runtimeLogsTickMsg struct {
 	AppUUID string
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -72,6 +72,7 @@ type screen int
 const (
 	screenList screen = iota
 	screenDetail
+	screenTail
 )
 
 // focusTarget is the pane keystrokes are routed to.
@@ -161,14 +162,19 @@ type Model struct {
 	deployments *views.Deployments
 	instances   *views.Instances
 	diagnostics *views.Diagnostics
+	tail        *views.Tail
 
 	// Sequence numbers and cancel functions implement request supersession:
 	// starting a new request of a kind cancels the previous one and bumps the
 	// sequence, so a late reply is both stopped and ignored.
-	connectSeq           uint64
-	dashboardSeq         uint64
-	detailSeq            uint64
-	runtimeLogsSeq       uint64
+	connectSeq     uint64
+	dashboardSeq   uint64
+	detailSeq      uint64
+	runtimeLogsSeq uint64
+	// tailSeq identifies one fleet-tail session. Every source's replies carry
+	// it, so leaving the tail orphans all of them at once without having to
+	// track a cancel function per application.
+	tailSeq              uint64
 	deploymentLogsSeq    uint64
 	operationSeq         uint64
 	cancelDashboard      context.CancelFunc
@@ -200,6 +206,9 @@ type Model struct {
 	// logLines is the session override of config.LogLines. +/- on the log
 	// view changes it without writing config back to disk.
 	logLines int
+
+	tailSearching  bool
+	tailSearchText string
 
 	paletteOpen     bool
 	paletteQuery    string
@@ -259,6 +268,7 @@ func New(opts Options) *Model {
 		deployments: views.NewDeployments(),
 		instances:   views.NewInstances(),
 		diagnostics: views.NewDiagnostics(),
+		tail:        views.NewTail(),
 		logLines:    logLines,
 		// Until the terminal reports its background colour, assume dark: it is
 		// by far the more common terminal configuration, so the wrong guess is
@@ -419,6 +429,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, m.pushToast(components.ToastError, msg.Err.Title, msg.Err.Message)
+
+	case tailTickMsg:
+		if msg.Seq != m.tailSeq || m.screen != screenTail || m.tail.Paused() {
+			return m, nil
+		}
+		return m, m.loadTailLogs(msg.AppUUID)
+
+	case tailLoadedMsg:
+		return m, m.applyTailLoaded(msg)
+
+	case tailFailedMsg:
+		return m, m.applyTailFailed(msg)
 
 	case runtimeLogsTickMsg:
 		if !m.runtimeLogsVisible(msg.AppUUID) {
@@ -761,7 +783,11 @@ func (m *Model) filterPrompt(width int) string {
 func (m *Model) logSearchPrompt(width int) string {
 	th := m.theme
 	prompt := th.FilterPrompt.Render("/ ")
-	text := th.FilterText.Render(m.logSearchText) + th.FilterPrompt.Render("▏")
+	query := m.logSearchText
+	if m.tailSearching {
+		query = m.tailSearchText
+	}
+	text := th.FilterText.Render(query) + th.FilterPrompt.Render("▏")
 	hint := th.FilterHint.Render("  enter apply  " + th.Sym.Separator + "  esc close")
 	line := prompt + text
 	if components.Width(line)+components.Width(hint) <= width {

--- a/internal/tui/tail.go
+++ b/internal/tui/tail.go
@@ -1,0 +1,156 @@
+package tui
+
+import (
+	"context"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+	"github.com/resetnak/cooldeck/internal/tui/views"
+)
+
+// tailInterval is how often each tailed application is re-read. It is
+// deliberately slower than the single-application log poll: the tail multiplies
+// every tick by the number of sources, and config.MinRefreshInterval exists
+// because Coolify's rate limit is shared with everything else the session does.
+const tailInterval = 4 * time.Second
+
+// tailStagger spreads the sources across the interval instead of firing them
+// all at once, so a fleet tail looks like a steady trickle to the API rather
+// than a burst every four seconds.
+func tailStagger(index, count int) time.Duration {
+	if count <= 1 {
+		return 0
+	}
+	return time.Duration(index) * tailInterval / time.Duration(count)
+}
+
+// openTail switches to the fleet tail for the marked applications.
+func (m *Model) openTail() (tea.Model, tea.Cmd) {
+	marked := m.apps.Marked()
+	if len(marked) == 0 {
+		return m, m.pushToast(components.ToastInfo, "Nothing marked",
+			"Press space on the applications list to mark what to tail.")
+	}
+
+	dropped := 0
+	if len(marked) > views.MaxTailApps {
+		dropped = len(marked) - views.MaxTailApps
+		marked = marked[:views.MaxTailApps]
+	}
+
+	m.tail.SetApplications(marked)
+	m.screen = screenTail
+	m.tailSeq++
+
+	cmds := make([]tea.Cmd, 0, len(marked)+1)
+	for i := range marked {
+		cmds = append(cmds, m.tailTick(marked[i].UUID, tailStagger(i, len(marked))))
+	}
+	if dropped > 0 {
+		// Say what was left out rather than silently tailing a subset.
+		cmds = append(cmds, m.pushToast(components.ToastWarning, "Tailing the first "+
+			itoa(views.MaxTailApps), itoa(dropped)+" more stayed behind; Coolify serves logs as whole snapshots, so each source is its own request."))
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// closeTail returns to the applications list and stops the polling.
+func (m *Model) closeTail() {
+	m.screen = screenList
+	// Bumping the sequence orphans every reply still in flight, which is how a
+	// set of concurrent requests is cancelled without tracking each one.
+	m.tailSeq++
+	m.tailSearching = false
+	m.tailSearchText = ""
+}
+
+// tailTick schedules the next read of one source.
+func (m *Model) tailTick(appUUID string, delay time.Duration) tea.Cmd {
+	seq := m.tailSeq
+	if delay <= 0 {
+		delay = tailInterval
+	}
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		return tailTickMsg{Seq: seq, AppUUID: appUUID}
+	})
+}
+
+// loadTailLogs reads one source. Unlike the single-application log request this
+// keeps no cancel function: several are in flight at once by design, and a
+// stale reply is dropped by its sequence number instead.
+func (m *Model) loadTailLogs(appUUID string) tea.Cmd {
+	seq := m.tailSeq
+	service := m.service
+	lines := m.opts.Config.LogLines
+	if lines <= 0 {
+		lines = 100
+	}
+
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+
+		snapshot, err := service.RuntimeLogs(ctx, appUUID, lines)
+		if err != nil {
+			return tailFailedMsg{Seq: seq, AppUUID: appUUID, Err: domain.AsError(err)}
+		}
+		return tailLoadedMsg{Seq: seq, AppUUID: appUUID, Snapshot: snapshot}
+	}
+}
+
+// applyTailLoaded stores one snapshot and schedules that source's next read.
+func (m *Model) applyTailLoaded(msg tailLoadedMsg) tea.Cmd {
+	if msg.Seq != m.tailSeq || m.screen != screenTail {
+		return nil
+	}
+	m.tail.SetLines(msg.AppUUID, msg.Snapshot.Lines, msg.Snapshot.LoadedAt)
+	if m.tail.Paused() {
+		return nil
+	}
+	return m.tailTick(msg.AppUUID, 0)
+}
+
+// applyTailFailed degrades one source without emptying the view, and backs off
+// rather than hammering an instance that is rate limiting or down.
+func (m *Model) applyTailFailed(msg tailFailedMsg) tea.Cmd {
+	if msg.Seq != m.tailSeq || m.screen != screenTail {
+		return nil
+	}
+	if msg.Err.Kind == domain.ErrorCancelled {
+		return nil
+	}
+
+	m.tail.SetFailure(msg.AppUUID, msg.Err.Title)
+	if m.tail.Paused() {
+		return nil
+	}
+
+	return m.tailTick(msg.AppUUID, tailRetryDelay(msg.Err))
+}
+
+// tailRetryDelay decides how long to wait before reading a source again after
+// a failure. A rate limit is obeyed to the second Coolify asked for, because
+// arguing with one is how it becomes a ban; anything else backs off to twice
+// the normal interval so a source that is simply down costs half as much.
+func tailRetryDelay(err *domain.Error) time.Duration {
+	if err != nil && err.Kind == domain.ErrorRateLimited && err.RetryAfter > 0 {
+		return err.RetryAfter
+	}
+	return tailInterval * 2
+}
+
+// itoa keeps the toast text free of a strconv import in this file.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/internal/tui/tail_test.go
+++ b/internal/tui/tail_test.go
@@ -1,0 +1,165 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/resetnak/cooldeck/internal/app"
+	"github.com/resetnak/cooldeck/internal/app/demo"
+	"github.com/resetnak/cooldeck/internal/config"
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/views"
+)
+
+func tailModel(t *testing.T) *Model {
+	t.Helper()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	service := demo.New(demo.Options{Now: func() time.Time { return now }})
+	snapshot, err := service.Dashboard(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	model := New(Options{Config: config.Default(), Service: service, Demo: true, ASCII: true})
+	model.apps.SetApplications(snapshot.Applications, snapshot.ActiveDeployments, now)
+	return model
+}
+
+func markFirst(t *testing.T, model *Model, n int) []string {
+	t.Helper()
+	uuids := make([]string, 0, n)
+	for i := range n {
+		a, ok := model.apps.At(i)
+		if !ok {
+			t.Fatalf("only %d applications available", i)
+		}
+		model.apps.SelectUUID(a.UUID)
+		if _, ok := model.apps.ToggleMark(); !ok {
+			t.Fatal("could not mark")
+		}
+		uuids = append(uuids, a.UUID)
+	}
+	return uuids
+}
+
+func TestTailNeedsSomethingMarked(t *testing.T) {
+	model := tailModel(t)
+
+	_, cmd := model.openTail()
+	if model.screen == screenTail {
+		t.Fatal("opened an empty tail")
+	}
+	if cmd == nil {
+		t.Fatal("the user was not told why nothing happened")
+	}
+}
+
+func TestTailStartsOnePollPerMarkedApplication(t *testing.T) {
+	model := tailModel(t)
+	uuids := markFirst(t, model, 3)
+
+	_, cmd := model.openTail()
+	if model.screen != screenTail {
+		t.Fatal("t did not open the tail")
+	}
+	if got := model.tail.Count(); got != 3 {
+		t.Fatalf("tailing %d applications, want 3", got)
+	}
+
+	// Every source has to be armed, or one of them would simply never update.
+	ticks := map[string]bool{}
+	collectTailTicks(cmd, ticks)
+	for _, uuid := range uuids {
+		if !ticks[uuid] {
+			t.Errorf("no poll scheduled for %s", uuid)
+		}
+	}
+}
+
+// collectTailTicks walks a command tree, running only the ticks, and records
+// which applications they belong to.
+func collectTailTicks(cmd tea.Cmd, into map[string]bool) {
+	if cmd == nil {
+		return
+	}
+	switch msg := cmd().(type) {
+	case tailTickMsg:
+		into[msg.AppUUID] = true
+	case tea.BatchMsg:
+		for _, sub := range msg {
+			collectTailTicks(sub, into)
+		}
+	}
+}
+
+func TestLeavingTheTailOrphansItsRepliesInFlight(t *testing.T) {
+	model := tailModel(t)
+	uuids := markFirst(t, model, 2)
+	model.openTail()
+	stale := model.tailSeq
+
+	model.closeTail()
+	if model.screen != screenList {
+		t.Fatal("esc did not return to the list")
+	}
+
+	// A reply from the tail the user just left must not schedule more work:
+	// bumping the sequence is what stands in for cancelling several requests.
+	_, cmd := model.Update(tailLoadedMsg{
+		Seq:      stale,
+		AppUUID:  uuids[0],
+		Snapshot: app.LogSnapshot{Lines: []domain.LogLine{{Text: "late"}}},
+	})
+	if cmd != nil {
+		t.Fatal("a stale reply scheduled another poll")
+	}
+}
+
+func TestRetryDelayObeysCoolifyOverTheDefault(t *testing.T) {
+	rateLimited := domain.NewError(domain.ErrorRateLimited, nil)
+	rateLimited.RetryAfter = 30 * time.Second
+
+	if got := tailRetryDelay(rateLimited); got != 30*time.Second {
+		t.Errorf("rate limited: waited %s, want the 30s Coolify asked for", got)
+	}
+	// A rate limit with no hint, and every other failure, falls back to backing
+	// off rather than retrying on the normal interval.
+	if got := tailRetryDelay(domain.NewError(domain.ErrorRateLimited, nil)); got != 2*tailInterval {
+		t.Errorf("rate limited without a hint: waited %s, want %s", got, 2*tailInterval)
+	}
+	if got := tailRetryDelay(domain.NewError(domain.ErrorNetwork, nil)); got != 2*tailInterval {
+		t.Errorf("network failure: waited %s, want %s", got, 2*tailInterval)
+	}
+}
+
+func TestFailedSourceIsRetriedNotDropped(t *testing.T) {
+	model := tailModel(t)
+	uuids := markFirst(t, model, 1)
+	model.openTail()
+
+	cmd := model.applyTailFailed(tailFailedMsg{
+		Seq: model.tailSeq, AppUUID: uuids[0],
+		Err: domain.NewError(domain.ErrorNetwork, nil),
+	})
+	if cmd == nil {
+		t.Fatal("a failing source was never retried")
+	}
+}
+
+func TestTailStaggerSpreadsSourcesAcrossTheInterval(t *testing.T) {
+	// All five firing at once would be a burst every tick, which is the thing
+	// the interval exists to avoid.
+	seen := map[time.Duration]bool{}
+	for i := range views.MaxTailApps {
+		d := tailStagger(i, views.MaxTailApps)
+		if seen[d] {
+			t.Fatalf("source %d shares its offset %s with an earlier one", i, d)
+		}
+		seen[d] = true
+		if d >= tailInterval {
+			t.Fatalf("offset %s is beyond the interval %s", d, tailInterval)
+		}
+	}
+}

--- a/internal/tui/testdata/fleet-tail.golden
+++ b/internal/tui/testdata/fleet-tail.golden
@@ -1,0 +1,40 @@
+ COOLDECK  Demo   o connected    DEMO                                                                                            12 apps  |  refreshed just now
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ RESOURCES               │FLEET TAIL
+                         │18 lines  shipyard-api  shipyard-web  billing-api  just now  follow
+ > Applications      12  │
+   Deployments        0  │>shipyard-api 2026-08-04T11:56:28Z INFO  INFO  GET /healthz 200 in 2ms
+   Instances          1  │>shipyard-web 2026-08-04T11:56:28Z INFO  INFO  GET /healthz 200 in 2ms
+   Diagnostics           │>shipyard-api 2026-08-04T11:56:35Z INFO  INFO  GET /api/v1/entries 200 in 31ms
+                         │>shipyard-web 2026-08-04T11:56:35Z INFO  INFO  GET /api/v1/entries 200 in 31ms
+                         │>shipyard-api 2026-08-04T11:56:42Z WARN  WARN  slow query detected: SELECT * FROM entries took 812ms
+                         │>shipyard-web 2026-08-04T11:56:42Z WARN  WARN  slow query detected: SELECT * FROM entries took 812ms
+                         │>shipyard-api 2026-08-04T11:56:49Z INFO  INFO  POST /api/v1/entries 201 in 64ms
+                         │>shipyard-web 2026-08-04T11:56:49Z INFO  INFO  POST /api/v1/entries 201 in 64ms
+                         │>billing-api  2026-08-04T11:56:49Z INFO  INFO  POST /api/v1/entries 201 in 64ms
+                         │>shipyard-api 2026-08-04T11:56:56Z INFO  INFO  GET /healthz 200 in 2ms
+                         │>shipyard-web 2026-08-04T11:56:56Z INFO  INFO  GET /healthz 200 in 2ms
+                         │>billing-api  2026-08-04T11:56:56Z INFO  INFO  GET /healthz 200 in 2ms
+                         │>shipyard-api 2026-08-04T11:57:03Z DEBUG DEBUG scheduled job 'digest' skipped, not due yet
+                         │>shipyard-web 2026-08-04T11:57:03Z DEBUG DEBUG scheduled job 'digest' skipped, not due yet
+                         │>billing-api  2026-08-04T11:57:03Z DEBUG DEBUG scheduled job 'digest' skipped, not due yet
+                         │>billing-api  2026-08-04T11:57:10Z WARN  WARN  health check /health returned 503
+                         │>billing-api  2026-08-04T11:57:17Z ERROR ERROR upstream dependency timed out after 5s
+                         │>billing-api  2026-08-04T11:57:24Z WARN  WARN  health check /health returned 503
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+                         │
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  ↑↓  navigate   enter  details   d  deploy   r  restart   s  start/stop   /  filter   S  sort: status   b  open domain   R  refresh   ?  more             1/12

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -118,6 +118,8 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch m.screen {
+	case screenTail:
+		return m.handleTailKey(msg)
 	case screenDetail:
 		return m.handleDetailKey(msg)
 	default:
@@ -232,6 +234,13 @@ func (m *Model) handleApplicationsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	page := max(m.contentHeight()-2, 1)
 
 	switch {
+	case key.Matches(msg, m.keys.Mark):
+		if marked, ok := m.apps.ToggleMark(); ok {
+			_ = marked
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.Tail):
+		return m.openTail()
 	case key.Matches(msg, m.keys.Up):
 		m.apps.Move(-1)
 	case key.Matches(msg, m.keys.Down):
@@ -780,4 +789,79 @@ func trimLastWord(s string) string {
 		return s[:i+1]
 	}
 	return ""
+}
+
+// handleTailKey drives the fleet tail. The bindings deliberately mirror the
+// single-application log view, so what the user already learned still works.
+func (m *Model) handleTailKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.tailSearching {
+		return m.handleTailSearchKey(msg)
+	}
+
+	page := max(m.contentHeight()-2, 1)
+
+	switch {
+	case key.Matches(msg, m.keys.Back), key.Matches(msg, m.keys.Quit):
+		m.closeTail()
+		return m, nil
+	case key.Matches(msg, m.keys.Up):
+		m.tail.Scroll(-1)
+	case key.Matches(msg, m.keys.Down):
+		m.tail.Scroll(1)
+	case key.Matches(msg, m.keys.PageUp):
+		m.tail.Scroll(-page)
+	case key.Matches(msg, m.keys.PageDown):
+		m.tail.Scroll(page)
+	case key.Matches(msg, m.keys.LogPause):
+		if paused := m.tail.TogglePause(); !paused {
+			// Resuming re-arms every source at once; they re-stagger from the
+			// replies that follow.
+			return m, m.resumeTail()
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.LogFollow):
+		m.tail.ToggleFollow()
+	case key.Matches(msg, m.keys.LogWrap):
+		m.tail.ToggleWrap()
+	case key.Matches(msg, m.keys.Filter):
+		m.tailSearching = true
+		m.tailSearchText = m.tail.Search()
+		return m, nil
+	case key.Matches(msg, m.keys.CopyUUID):
+		return m, m.copyText(m.tail.Text(), "Tail copied")
+	}
+	return m, nil
+}
+
+func (m *Model) handleTailSearchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(msg, m.keys.Cancel) || key.Matches(msg, m.keys.Confirm) {
+		m.tailSearching = false
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "backspace":
+		if runes := []rune(m.tailSearchText); len(runes) > 0 {
+			m.tailSearchText = string(runes[:len(runes)-1])
+		}
+	case "ctrl+u":
+		m.tailSearchText = ""
+	default:
+		// String() renders space as "space"; Text carries the literal input.
+		if text := msg.Key().Text; text != "" {
+			m.tailSearchText += text
+		}
+	}
+	m.tail.SetSearch(m.tailSearchText)
+	return m, nil
+}
+
+// resumeTail re-arms every source after a pause.
+func (m *Model) resumeTail() tea.Cmd {
+	uuids := m.tail.UUIDs()
+	cmds := make([]tea.Cmd, 0, len(uuids))
+	for i, uuid := range uuids {
+		cmds = append(cmds, m.tailTick(uuid, tailStagger(i, len(uuids))))
+	}
+	return tea.Batch(cmds...)
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -76,7 +76,7 @@ func (m *Model) renderBody() string {
 	if m.filtering {
 		banners = append(banners, m.filterPrompt(m.layout.Width))
 	}
-	if m.logSearching {
+	if m.logSearching || m.tailSearching {
 		banners = append(banners, m.logSearchPrompt(m.layout.Width))
 	}
 	if stale := m.staleFor(); stale > 0 {
@@ -139,6 +139,9 @@ func (m *Model) renderMain(width, height int) string {
 		})
 	}
 
+	if m.screen == screenTail {
+		return m.tail.Render(th, width, height, now)
+	}
 	if m.screen == screenDetail {
 		return m.renderDetail(width, height, now)
 	}
@@ -174,7 +177,8 @@ func (m *Model) renderDetail(width, height int, now time.Time) string {
 // An empty result means there is nothing worth a column, and the caller widens
 // the main content instead.
 func (m *Model) previewContent(width, height int) string {
-	if m.section != SectionApplications || m.screen == screenDetail {
+	// Both the detail screen and the fleet tail take the full content area.
+	if m.section != SectionApplications || m.screen != screenList {
 		return ""
 	}
 	a, ok := m.apps.Selected()

--- a/internal/tui/views/applications.go
+++ b/internal/tui/views/applications.go
@@ -62,6 +62,10 @@ type Applications struct {
 	selected     int
 	offset       int
 
+	// marked holds the applications picked for the fleet tail, keyed by UUID so
+	// a refresh that reorders or filters the table cannot lose the selection.
+	marked map[string]bool
+
 	loaded   bool
 	loadedAt time.Time
 }
@@ -137,6 +141,45 @@ func (v *Applications) At(i int) (domain.Application, bool) {
 		return domain.Application{}, false
 	}
 	return v.visible[i], true
+}
+
+// ToggleMark marks or unmarks the selected application and returns the new
+// state. Marks survive filtering and sorting because they are keyed by UUID.
+func (v *Applications) ToggleMark() (marked bool, ok bool) {
+	a, ok := v.Selected()
+	if !ok {
+		return false, false
+	}
+	if v.marked == nil {
+		v.marked = map[string]bool{}
+	}
+	if v.marked[a.UUID] {
+		delete(v.marked, a.UUID)
+		return false, true
+	}
+	v.marked[a.UUID] = true
+	return true, true
+}
+
+// ClearMarks drops every mark.
+func (v *Applications) ClearMarks() { v.marked = nil }
+
+// MarkCount returns how many applications are marked.
+func (v *Applications) MarkCount() int { return len(v.marked) }
+
+// Marked returns the marked applications in display order, so the tail shows
+// them in the order the table does rather than in map order.
+func (v *Applications) Marked() []domain.Application {
+	if len(v.marked) == 0 {
+		return nil
+	}
+	out := make([]domain.Application, 0, len(v.marked))
+	for _, a := range v.all {
+		if v.marked[a.UUID] {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // ActiveDeployment returns the in-flight deployment for an application.
@@ -297,6 +340,11 @@ func (v *Applications) cells(th *theme.Theme, a domain.Application, now time.Tim
 	}
 
 	name := a.Name
+	if v.marked[a.UUID] {
+		// Same treatment as the production bullet below: a glyph, never colour
+		// alone, and in front of it so a marked production app shows both.
+		name = th.Accent.Render(th.Sym.Check) + " " + name
+	}
 	if a.IsProduction() {
 		// Production is marked with a glyph rather than colour alone.
 		name = th.Danger.Render(th.Sym.Bullet) + " " + name

--- a/internal/tui/views/detail.go
+++ b/internal/tui/views/detail.go
@@ -1,7 +1,6 @@
 package views
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -508,69 +507,13 @@ func (v *Detail) renderRuntimeLogs(th *theme.Theme, width, height int, now time.
 	)
 }
 
-type logContent struct {
-	title       string
-	meta        string
-	lines       []domain.LogLine
-	wrap        bool
-	follow      bool
-	trackScroll bool
-	search      string
-}
-
 func (v *Detail) renderLogs(th *theme.Theme, width, height int, content logContent) string {
-	lines := []string{th.Title.Render(content.title), th.Subtle.Render(content.meta), ""}
-	var search *regexp.Regexp
-	if content.search != "" {
-		search = regexp.MustCompile("(?i)" + regexp.QuoteMeta(content.search))
-	}
-	for _, line := range content.lines {
-		timestamp := line.TimestampText
-		if timestamp == "" && !line.Timestamp.IsZero() {
-			timestamp = line.Timestamp.Format("15:04:05")
-		}
-		prefix := ""
-		if timestamp != "" {
-			prefix = th.Subtle.Render(timestamp) + " "
-		}
-		if label := line.Level.Label(); label != "" {
-			prefix += logLevelStyle(th, line.Level).Render(components.Pad(label, 5)) + " "
-		}
-		text := prefix + line.Text
-		if search != nil {
-			text = search.ReplaceAllStringFunc(text, func(match string) string {
-				return th.FilterPrompt.Render(match)
-			})
-		}
-		if content.wrap {
-			lines = append(lines, strings.Split(components.Wrap(text, width), "\n")...)
-		} else {
-			lines = append(lines, components.Truncate(text, width, th.Sym.Ellipsis))
-		}
-	}
-
-	maxScroll := max(len(lines)-height, 0)
+	body, scroll, maxScroll := renderLogBlock(th, width, height, content, v.scroll)
 	if content.trackScroll {
 		v.logMaxScroll = maxScroll
 	}
-	if content.follow {
-		v.scroll = maxScroll
-	}
-	v.scroll = min(v.scroll, maxScroll)
-	return components.FitBlock(strings.Join(lines[v.scroll:], "\n"), width, height)
-}
-
-func logLevelStyle(th *theme.Theme, level domain.LogLevel) lipgloss.Style {
-	switch level {
-	case domain.LogLevelWarn:
-		return th.Attention
-	case domain.LogLevelError, domain.LogLevelFatal:
-		return th.Danger
-	case domain.LogLevelInfo:
-		return th.Note
-	default:
-		return th.Subtle
-	}
+	v.scroll = scroll
+	return body
 }
 
 func joinLogLines(lines []domain.LogLine) string {

--- a/internal/tui/views/logrender.go
+++ b/internal/tui/views/logrender.go
@@ -1,0 +1,89 @@
+package views
+
+import (
+	"regexp"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+	"github.com/resetnak/cooldeck/internal/tui/theme"
+)
+
+// logContent is one rendered log buffer. The detail screen and the fleet tail
+// share it so their ergonomics - follow, wrap, search highlighting - cannot
+// drift apart.
+type logContent struct {
+	title       string
+	meta        string
+	lines       []domain.LogLine
+	wrap        bool
+	follow      bool
+	trackScroll bool
+	search      string
+	// tag returns a per-line prefix, used by the fleet tail to name the
+	// application a line came from. Nil for a single-application buffer.
+	tag func(i int) string
+}
+
+// renderLogBlock draws the buffer and returns the body along with the resolved
+// scroll position, so the caller owns the scroll state rather than this
+// function reaching back into a view.
+func renderLogBlock(th *theme.Theme, width, height int, content logContent, scroll int) (body string, resolved, maxScroll int) {
+	lines := []string{th.Title.Render(content.title), th.Subtle.Render(content.meta), ""}
+
+	var search *regexp.Regexp
+	if content.search != "" {
+		search = regexp.MustCompile("(?i)" + regexp.QuoteMeta(content.search))
+	}
+
+	for i, line := range content.lines {
+		prefix := ""
+		if content.tag != nil {
+			prefix = content.tag(i)
+		}
+		timestamp := line.TimestampText
+		if timestamp == "" && !line.Timestamp.IsZero() {
+			timestamp = line.Timestamp.Format("15:04:05")
+		}
+		if timestamp != "" {
+			prefix += th.Subtle.Render(timestamp) + " "
+		}
+		if label := line.Level.Label(); label != "" {
+			prefix += logLevelStyle(th, line.Level).Render(components.Pad(label, 5)) + " "
+		}
+
+		text := prefix + line.Text
+		if search != nil {
+			text = search.ReplaceAllStringFunc(text, func(match string) string {
+				return th.FilterPrompt.Render(match)
+			})
+		}
+		if content.wrap {
+			lines = append(lines, strings.Split(components.Wrap(text, width), "\n")...)
+		} else {
+			lines = append(lines, components.Truncate(text, width, th.Sym.Ellipsis))
+		}
+	}
+
+	maxScroll = max(len(lines)-height, 0)
+	if content.follow {
+		scroll = maxScroll
+	}
+	scroll = min(max(scroll, 0), maxScroll)
+	return components.FitBlock(strings.Join(lines[scroll:], "\n"), width, height), scroll, maxScroll
+}
+
+func logLevelStyle(th *theme.Theme, level domain.LogLevel) lipgloss.Style {
+	switch level {
+	case domain.LogLevelWarn:
+		return th.Attention
+	case domain.LogLevelError, domain.LogLevelFatal:
+		return th.Danger
+	case domain.LogLevelInfo:
+		return th.Note
+	default:
+		return th.Subtle
+	}
+}

--- a/internal/tui/views/tail.go
+++ b/internal/tui/views/tail.go
@@ -1,0 +1,310 @@
+package views
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+	"github.com/resetnak/cooldeck/internal/tui/theme"
+)
+
+// MaxTailApps caps how many applications can be tailed at once. Coolify serves
+// logs as whole snapshots rather than a stream, so every tailed application is
+// a separate poll on every tick - the same rate limit config.MinRefreshInterval
+// exists to protect. Five is also about as many interleaved streams as anyone
+// can actually read.
+const MaxTailApps = 5
+
+// tailSource is one application's latest log snapshot.
+type tailSource struct {
+	uuid     string
+	name     string
+	lines    []domain.LogLine
+	loadedAt time.Time
+	// failure is the last error text for this source, kept so one unreachable
+	// application degrades to a note in the header instead of emptying the view.
+	failure string
+}
+
+// Tail merges the runtime logs of several applications into one buffer.
+//
+// Lines are ordered by timestamp where the source provides one. A line without
+// a timestamp inherits the one before it from the same application, so a stack
+// trace stays under the line it belongs to; an application that prints no
+// timestamps at all is ordered by when its snapshot was taken.
+type Tail struct {
+	sources []tailSource
+	loaded  bool
+
+	follow bool
+	paused bool
+	wrap   bool
+	search string
+	match  int
+	scroll int
+
+	maxScroll int
+}
+
+// NewTail returns an empty tail view.
+func NewTail() *Tail { return &Tail{follow: true} }
+
+// SetApplications resets the view to a new set of applications, preserving any
+// snapshot already held for one that stays.
+func (v *Tail) SetApplications(apps []domain.Application) {
+	previous := make(map[string]tailSource, len(v.sources))
+	for _, s := range v.sources {
+		previous[s.uuid] = s
+	}
+
+	v.sources = make([]tailSource, 0, min(len(apps), MaxTailApps))
+	for _, a := range apps {
+		if len(v.sources) == MaxTailApps {
+			break
+		}
+		source := tailSource{uuid: a.UUID, name: a.Name}
+		if old, ok := previous[a.UUID]; ok {
+			source = old
+			source.name = a.Name
+		}
+		v.sources = append(v.sources, source)
+	}
+	v.loaded = false
+	v.scroll = 0
+}
+
+// UUIDs lists the applications being tailed, in display order.
+func (v *Tail) UUIDs() []string {
+	out := make([]string, 0, len(v.sources))
+	for _, s := range v.sources {
+		out = append(out, s.uuid)
+	}
+	return out
+}
+
+// Count returns how many applications are being tailed.
+func (v *Tail) Count() int { return len(v.sources) }
+
+// SetLines stores one application's snapshot.
+func (v *Tail) SetLines(uuid string, lines []domain.LogLine, at time.Time) {
+	for i := range v.sources {
+		if v.sources[i].uuid != uuid {
+			continue
+		}
+		v.sources[i].lines = append([]domain.LogLine{}, lines...)
+		v.sources[i].loadedAt = at
+		v.sources[i].failure = ""
+		v.loaded = true
+		return
+	}
+}
+
+// SetFailure records that one source could not be read. The rest keep working.
+func (v *Tail) SetFailure(uuid, reason string) {
+	for i := range v.sources {
+		if v.sources[i].uuid == uuid {
+			v.sources[i].failure = reason
+			v.loaded = true
+			return
+		}
+	}
+}
+
+// Loaded reports whether at least one snapshot has arrived.
+func (v *Tail) Loaded() bool { return v.loaded }
+
+// Paused reports whether polling is suspended.
+func (v *Tail) Paused() bool { return v.paused }
+
+// TogglePause suspends or resumes polling and returns the new state.
+func (v *Tail) TogglePause() bool {
+	v.paused = !v.paused
+	return v.paused
+}
+
+// Following reports whether the view stays pinned to the newest line.
+func (v *Tail) Following() bool { return v.follow }
+
+// ToggleFollow pins or unpins the tail and returns the new state.
+func (v *Tail) ToggleFollow() bool {
+	v.follow = !v.follow
+	return v.follow
+}
+
+// ToggleWrap switches line wrapping and returns the new state.
+func (v *Tail) ToggleWrap() bool {
+	v.wrap = !v.wrap
+	return v.wrap
+}
+
+// Search returns the active query.
+func (v *Tail) Search() string { return v.search }
+
+// SetSearch replaces the query and resets the match cursor.
+func (v *Tail) SetSearch(query string) {
+	v.search = query
+	v.match = 0
+}
+
+// Scroll moves the buffer by delta lines and drops out of follow mode, because
+// scrolling up while pinned to the tail would fight the user.
+func (v *Tail) Scroll(delta int) {
+	if delta < 0 {
+		v.follow = false
+	}
+	v.scroll = min(max(v.scroll+delta, 0), v.maxScroll)
+}
+
+// Text returns the merged buffer as plain text for copying.
+func (v *Tail) Text() string {
+	entries := v.merged(time.Time{})
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		parts = append(parts, e.name+"  "+e.line.String())
+	}
+	return strings.Join(parts, "\n")
+}
+
+// entry is one line with the application it came from.
+type entry struct {
+	name string
+	// tagIndex selects the colour, so an application keeps the same one for as
+	// long as it is being tailed.
+	tagIndex int
+	line     domain.LogLine
+	at       time.Time
+}
+
+// merged flattens the sources into one time-ordered buffer.
+func (v *Tail) merged(now time.Time) []entry {
+	total := 0
+	for _, s := range v.sources {
+		total += len(s.lines)
+	}
+	entries := make([]entry, 0, total)
+
+	for i, s := range v.sources {
+		// Carry the last seen timestamp forward so continuation lines stay
+		// with the line they belong to.
+		carried := s.loadedAt
+		if carried.IsZero() {
+			carried = now
+		}
+		for _, line := range s.lines {
+			if !line.Timestamp.IsZero() {
+				carried = line.Timestamp
+			}
+			entries = append(entries, entry{name: s.name, tagIndex: i, line: line, at: carried})
+		}
+	}
+
+	// A stable sort keeps each application's own lines in the order it printed
+	// them, even when several share a timestamp.
+	sortStableByTime(entries)
+	return entries
+}
+
+func sortStableByTime(entries []entry) {
+	// Insertion sort: the buffer is already almost ordered - each source is
+	// internally sorted - and this keeps equal timestamps in source order.
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0 && entries[j].at.Before(entries[j-1].at); j-- {
+			entries[j], entries[j-1] = entries[j-1], entries[j]
+		}
+	}
+}
+
+// tagStyles colours the application name on each line. They are existing theme
+// styles rather than new colours, so the WCAG contrast test already covers
+// them, and there are exactly as many as MaxTailApps.
+func tagStyles(th *theme.Theme) []lipgloss.Style {
+	return []lipgloss.Style{th.Accent, th.Note, th.Positive, th.Label, th.Strong}
+}
+
+// Render draws the merged buffer.
+func (v *Tail) Render(th *theme.Theme, width, height int, now time.Time) string {
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+	if len(v.sources) == 0 {
+		return components.EmptyState(th, width, height,
+			"Nothing selected to tail",
+			"Mark applications with space on the applications list, then press t.",
+			[]components.KeyHint{{Key: "1", Desc: "applications"}, {Key: "esc", Desc: "back"}})
+	}
+	if !v.loaded {
+		return components.Skeleton(th, width, height)
+	}
+
+	entries := v.merged(now)
+	lines := make([]domain.LogLine, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, e.line)
+	}
+
+	styles := tagStyles(th)
+	// The widest name sets the gutter, so the log text lines up across sources.
+	nameWidth := 0
+	for _, s := range v.sources {
+		nameWidth = max(nameWidth, components.Width(s.name))
+	}
+	nameWidth = min(nameWidth, 20)
+
+	tag := func(i int) string {
+		e := entries[i]
+		style := styles[e.tagIndex%len(styles)]
+		return style.Render(th.Sym.Selected+components.Pad(components.Truncate(e.name, nameWidth, ""), nameWidth)) + " "
+	}
+
+	body, scroll, maxScroll := renderLogBlock(th, width, height, logContent{
+		title:  "FLEET TAIL",
+		meta:   v.meta(now, len(entries)),
+		lines:  lines,
+		wrap:   v.wrap,
+		follow: v.follow,
+		search: v.search,
+		tag:    tag,
+	}, v.scroll)
+	v.scroll = scroll
+	v.maxScroll = maxScroll
+	return body
+}
+
+func (v *Tail) meta(now time.Time, count int) string {
+	names := make([]string, 0, len(v.sources))
+	for _, s := range v.sources {
+		label := s.name
+		if s.failure != "" {
+			label += " (" + s.failure + ")"
+		}
+		names = append(names, label)
+	}
+
+	meta := strconv.Itoa(count) + " lines  " + strings.Join(names, "  ")
+	newest := time.Time{}
+	for _, s := range v.sources {
+		if s.loadedAt.After(newest) {
+			newest = s.loadedAt
+		}
+	}
+	if !newest.IsZero() {
+		meta += "  " + domain.HumanizeAge(newest, now)
+	}
+	if v.paused {
+		meta += "  paused"
+	}
+	if v.follow {
+		meta += "  follow"
+	}
+	if v.wrap {
+		meta += "  wrap"
+	}
+	if v.search != "" {
+		meta += "  /" + v.search
+	}
+	return meta
+}

--- a/internal/tui/views/tail_test.go
+++ b/internal/tui/views/tail_test.go
@@ -1,0 +1,126 @@
+package views
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/theme"
+)
+
+func tailTheme(t *testing.T) *theme.Theme {
+	t.Helper()
+	return theme.New(theme.Options{Mode: theme.ModeDark, ASCII: true})
+}
+
+func at(clock time.Time, offset time.Duration, text string) domain.LogLine {
+	return domain.LogLine{Timestamp: clock.Add(offset), Text: text}
+}
+
+func TestTailInterleavesSourcesByTimestamp(t *testing.T) {
+	clock := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	v := NewTail()
+	v.SetApplications([]domain.Application{{UUID: "a", Name: "api"}, {UUID: "b", Name: "web"}})
+
+	v.SetLines("a", []domain.LogLine{at(clock, 0, "api first"), at(clock, 2*time.Second, "api third")}, clock)
+	v.SetLines("b", []domain.LogLine{at(clock, time.Second, "web second")}, clock)
+
+	var got []string
+	for _, e := range v.merged(clock) {
+		got = append(got, e.line.Text)
+	}
+	want := []string{"api first", "web second", "api third"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestTailKeepsContinuationLinesWithTheirParent(t *testing.T) {
+	clock := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	v := NewTail()
+	v.SetApplications([]domain.Application{{UUID: "a", Name: "api"}, {UUID: "b", Name: "web"}})
+
+	// A stack trace: only the first line carries a timestamp. Sorting the
+	// untimed lines to the front would tear the trace apart.
+	v.SetLines("a", []domain.LogLine{
+		at(clock, time.Second, "panic: boom"),
+		{Text: "  goroutine 1"},
+		{Text: "  main.go:42"},
+	}, clock)
+	v.SetLines("b", []domain.LogLine{at(clock, 2*time.Second, "web after")}, clock)
+
+	var got []string
+	for _, e := range v.merged(clock) {
+		got = append(got, e.line.Text)
+	}
+	want := []string{"panic: boom", "  goroutine 1", "  main.go:42", "web after"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestTailCapsTheNumberOfSources(t *testing.T) {
+	v := NewTail()
+	apps := make([]domain.Application, 0, MaxTailApps+3)
+	for i := range MaxTailApps + 3 {
+		apps = append(apps, domain.Application{UUID: string(rune('a' + i)), Name: "app"})
+	}
+	v.SetApplications(apps)
+
+	// Every source is a separate poll on every tick, so the cap is a rate-limit
+	// guard, not a display preference.
+	if v.Count() != MaxTailApps {
+		t.Fatalf("tailing %d applications, want at most %d", v.Count(), MaxTailApps)
+	}
+}
+
+func TestTailKeepsSnapshotsAcrossAReselect(t *testing.T) {
+	clock := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	v := NewTail()
+	v.SetApplications([]domain.Application{{UUID: "a", Name: "api"}})
+	v.SetLines("a", []domain.LogLine{at(clock, 0, "keep me")}, clock)
+
+	// Marking another application must not blank the buffer of one already
+	// being tailed.
+	v.SetApplications([]domain.Application{{UUID: "a", Name: "api"}, {UUID: "b", Name: "web"}})
+	if len(v.merged(clock)) != 1 {
+		t.Fatalf("re-selecting dropped the existing snapshot")
+	}
+}
+
+func TestTailFailureDegradesOneSourceOnly(t *testing.T) {
+	clock := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	th := tailTheme(t)
+	v := NewTail()
+	v.SetApplications([]domain.Application{{UUID: "a", Name: "api"}, {UUID: "b", Name: "web"}})
+	v.SetLines("a", []domain.LogLine{at(clock, 0, "still here")}, clock)
+	v.SetFailure("b", "Permission denied")
+
+	out := ansi.Strip(v.Render(th, 120, 20, clock))
+	if !strings.Contains(out, "still here") {
+		t.Error("a failing source emptied the view")
+	}
+	if !strings.Contains(out, "Permission denied") {
+		t.Error("the failure is not reported in the header")
+	}
+}
+
+func TestTailScrollingUpLeavesFollowMode(t *testing.T) {
+	v := NewTail()
+	if !v.Following() {
+		t.Fatal("a new tail should follow")
+	}
+	// Scrolling back while pinned to the newest line would fight the user on
+	// every poll.
+	v.Scroll(-1)
+	if v.Following() {
+		t.Fatal("scrolling up did not leave follow mode")
+	}
+}


### PR DESCRIPTION
Reading logs meant one application at a time: open the detail, read, `esc`, open the next. That is fine when you know which service is failing, and useless during the incident where you do not - you end up assembling a timeline in your head from three screens.

Mark applications with `space`, press `t`:

```
FLEET TAIL
18 lines  shipyard-api  shipyard-web  billing-api  just now  follow

▌shipyard-api 11:56:42 WARN  slow query detected: SELECT * FROM entries took 812ms
▌shipyard-web 11:56:49 INFO  POST /api/v1/entries 201 in 64ms
▌billing-api  11:57:10 WARN  health check /health returned 503
▌billing-api  11:57:17 ERROR upstream dependency timed out after 5s
```

Nothing else in the Coolify ecosystem does this - the web UI is one application per tab.

## Ordering, honestly

By timestamp where the source gives one. A line **without** a timestamp inherits the one before it from the same application, so a stack trace stays under the line it belongs to instead of being sorted to the front; an application that prints no timestamps at all is ordered by when its snapshot was taken. Both cases are tested.

## The rate-limit shape

Coolify serves logs as whole snapshots rather than a stream, so every tailed application is its own poll on every tick - against the rate limit `config.MinRefreshInterval` already exists to protect. The design follows from that constraint rather than working around it:

- **at most 5 sources** (`views.MaxTailApps`), a guard first and a readability limit second
- **a slower interval** than the single-application poll (4s vs 2s)
- **staggered starts**, so it looks like a trickle rather than a burst every tick
- **a failure degrades one source**, labelled in the header, retried with backoff - a rate limit is obeyed for exactly as long as Coolify asked for
- roughly one request per second at full tilt, which is less than the dashboard refresh already costs

## The invariant this breaks

This is the first request kind that keeps several requests in flight at once. One `tailSeq` covers the whole tail: leaving it orphans every reply at once, without a map of cancel functions on the `Model`. [ADR 0007](docs/decisions/0007-fleet-tail-concurrency.md) records the decision and its cost (cancellation is coarser - replies are ignored, not aborted, bounded by the 20s request timeout), and CLAUDE.md now states the exception rather than leaving the invariant looking absolute.

## Reuse rather than duplication

The log renderer moved out of `Detail` into a shared `renderLogBlock`, so follow, wrap and search-highlighting cannot drift apart between the two screens. It gained one field: an optional per-line tag, which is what names the application.

The tag colours are existing theme styles (`Accent`, `Note`, `Positive`, `Label`, `Strong`) rather than new ones, so the WCAG AA palette test already covers them - and there are exactly as many as the source cap.

## Testing

Ten new tests. The ones worth naming: interleaving by timestamp, continuation lines staying with their parent, the source cap holding, snapshots surviving a re-selection, one failing source not emptying the view, scrolling up leaving follow mode, every marked application getting a poll armed, a stale reply from a closed tail scheduling nothing, and the retry delay preferring Coolify's `RetryAfter` over the default backoff.

New golden `fleet-tail`; `make check` and `staticcheck` clean.