### PR TITLE
Polish the repository and prepare v0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something behaves differently from what the docs or the UI promise.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: `cooldeck --demo` needs no Coolify instance, so it is a quick way to tell a
+        UI bug from an instance-specific one.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what you got instead.
+      placeholder: |
+        1. Opened the deployments section
+        2. Pressed a
+        3. Expected only in-flight deployments; the list stayed empty
+    validations:
+      required: true
+
+  - type: dropdown
+    id: reproduces-in-demo
+    attributes:
+      label: Does it reproduce in demo mode?
+      description: Run `cooldeck --demo` and try the same steps.
+      options:
+        - "Yes, it reproduces in --demo"
+        - "No, only against my Coolify instance"
+        - "Not applicable"
+    validations:
+      required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: Paste the output of `cooldeck version`.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: coolify-version
+    attributes:
+      label: Coolify version
+      description: Skip this if the bug reproduces in demo mode.
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal and size
+      placeholder: iTerm2, 180x50
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        Press `4` then `c` to copy the diagnostics, and paste them here. They are secret-free by
+        construction - no token ever reaches that screen.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Resetnak/cooldeck/security/advisories/new
+    about: Report privately rather than in a public issue. See SECURITY.md.
+  - name: Coolify itself
+    url: https://github.com/coollabsio/coolify/issues
+    about: CoolDeck is a client. Bugs in Coolify's API or dashboard belong there.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Something CoolDeck should be able to do and cannot.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: |
+        Describe the situation rather than the solution. What were you doing when CoolDeck got in
+        the way, and what did you do instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would help
+      description: Optional. If you already have a shape in mind, describe it here.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Which surface?
+      options:
+        - The TUI
+        - The MCP server
+        - The CLI (setup, auth, config)
+        - Packaging and installation
+        - Not sure
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!-- What changes, and why it is worth changing. The commit messages carry the
+     detail; this is the summary a reviewer reads first. -->
+
+## Checks
+
+- [ ] `make check` passes (fmt, vet, tests, build)
+- [ ] Golden snapshots reviewed, not just regenerated - an unexpected diff is usually a real regression
+- [ ] Keybindings, if any, are defined only in `internal/tui/keys.go`
+- [ ] Anything touching Coolify goes through `app.Service`, not straight to HTTP
+- [ ] User-visible failures carry an actionable title and suggestion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/) once tagged
 releases begin.
 
-## [Unreleased]
+## [0.2.0] - 2026-08-05
 
 ### Added
 
-- Fleet tail: mark applications with `space`, press `t`, and read their runtime logs interleaved in one buffer
+- Fleet tail: mark applications with `space`, press `t`, and read their runtime logs interleaved in
+  one buffer, each line named and coloured by the application it came from
 
 ## [0.1.2] - 2026-08-05
 
@@ -44,7 +45,8 @@ Packaging only - the binary is identical to 0.1.0.
 - Command palette with fuzzy filter and disabled reasons
 - Help overlay with full key map
 - Instances section: mid-session switch, test connection, **add / edit / delete** local config
-- Deployments section: recent history with active-only filter
+- Deployments section: recent history with active-only filter, in-flight deployments first
+- Deployment progress against the median of an application's last five successful builds
 - Diagnostics section with copy and file export
 - Interactive `cooldeck setup` and `cooldeck theme` wizards
 - Theme set: auto, dark, light, Dracula, Catppuccin, Nord, Gruvbox, Tokyo Night
@@ -63,6 +65,7 @@ Packaging only - the binary is identical to 0.1.0.
 - Tokens excluded from logs, toasts, and diagnostics
 - Browser open restricted to http(s) URLs
 
+[0.2.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.2.0
 [0.1.2]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.2
 [0.1.1]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, colour, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing these standards
+and will take appropriate and fair corrective action in response to any
+behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, issues, and other contributions that are not aligned to
+this Code of Conduct, and will communicate reasons for moderation decisions when
+appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the maintainers at **mail@resetnak.cz**. All complaints will be
+reviewed and investigated promptly and fairly. Maintainers are obligated to
+respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/README.cs.md
+++ b/README.cs.md
@@ -14,6 +14,7 @@ z terminálu, který stejně máte otevřený.
 [![CI](https://github.com/Resetnak/cooldeck/actions/workflows/ci.yml/badge.svg)](https://github.com/Resetnak/cooldeck/actions/workflows/ci.yml)
 [![Bezpečnost](https://github.com/Resetnak/cooldeck/actions/workflows/security.yml/badge.svg)](https://github.com/Resetnak/cooldeck/actions/workflows/security.yml)
 [![Go](https://img.shields.io/badge/Go-1.26.5%2B-00ADD8?logo=go&logoColor=white)](go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/resetnak/cooldeck)](https://goreportcard.com/report/github.com/resetnak/cooldeck)
 [![Licence: MIT](https://img.shields.io/badge/Licence-MIT-green.svg)](LICENSE)
 [![Platformy](https://img.shields.io/badge/testov%C3%A1no-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-yellow)](.github/workflows/ci.yml)
 [![Coolify API](https://img.shields.io/badge/Coolify-API%20v1-8B5CF6)](docs/coolify-api.md)
@@ -434,7 +435,8 @@ databáze a servery a neinteraktivní CLI pro skripty a CI.
 ## 🤝 Přispívání
 
 Hlášení chyb, návrhy funkcí i PR jsou vítané - v [CONTRIBUTING.md](CONTRIBUTING.md) najdete lokální
-setup, workflow golden testů a co má projít před review přes `make check`.
+setup, workflow golden testů a co má projít před review přes `make check`. Účast se řídí
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## 📄 Licence
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ from the terminal you already have open.
 [![CI](https://github.com/Resetnak/cooldeck/actions/workflows/ci.yml/badge.svg)](https://github.com/Resetnak/cooldeck/actions/workflows/ci.yml)
 [![Security](https://github.com/Resetnak/cooldeck/actions/workflows/security.yml/badge.svg)](https://github.com/Resetnak/cooldeck/actions/workflows/security.yml)
 [![Go](https://img.shields.io/badge/Go-1.26.5%2B-00ADD8?logo=go&logoColor=white)](go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/resetnak/cooldeck)](https://goreportcard.com/report/github.com/resetnak/cooldeck)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Platforms](https://img.shields.io/badge/tested-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-yellow)](.github/workflows/ci.yml)
 [![Coolify API](https://img.shields.io/badge/Coolify-API%20v1-8B5CF6)](docs/coolify-api.md)
@@ -433,7 +434,8 @@ databases and servers, and a non-interactive CLI for scripts and CI.
 ## 🤝 Contributing
 
 Bug reports, feature requests and PRs are welcome - see [CONTRIBUTING.md](CONTRIBUTING.md) for the
-local setup, the golden-test workflow and what `make check` expects before review.
+local setup, the golden-test workflow and what `make check` expects before review. Participation is
+covered by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## 📄 License
 


### PR DESCRIPTION
Repository housekeeping plus the 0.2.0 changelog entry.

**Issue forms** rather than a blank box. The bug form asks the one question that halves triage time - *does it reproduce in `--demo`* - which separates a UI bug from an instance-specific one, and points at the diagnostics screen (secret-free by construction). A contact link routes security reports to a private advisory and Coolify bugs upstream.

**PR template** lists the invariants a reviewer would otherwise have to hold in their head: golden diffs reviewed rather than regenerated, keybindings only in `keys.go`, Coolify access only through `app.Service`.

**Changelog.** 0.2.0 for the fleet tail. 0.1.0 also gains two bullets it should have had - deployment progress and in-flight-first queue ordering both shipped in that release undocumented.

Also: Code of Conduct (the only gap left in GitHub's community profile), a Go Report Card badge, repository description and topics, and delete-branch-on-merge so merged branches stop piling up.

https://claude.ai/code/session_01YU2MN5vUbJkE3v9j2sVuvn