### PR TITLE
Prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/) once tagged
 releases begin.
 
-## [Unreleased]
+## [0.2.1] - 2026-08-05
 
 ### Fixed
 
@@ -18,6 +18,13 @@ releases begin.
   applications list's deploy and restart hints
 - Linux package install commands pointed at `/releases/latest/download/cooldeck_0.1.2_…`, a URL that
   404s after any release; they now resolve the current tag first
+
+### Added
+
+- `assets/tail.gif` and a dedicated fleet tail section in both READMEs, rendered from `tail.tape`
+- `assets/social-preview.png`, rendered from `social.tape`
+- The security section now states what CoolDeck does not protect you from: a `plaintext` token
+  source, `insecure_skip_verify`, and MCP mutations running without a confirmation
 
 ## [0.2.0] - 2026-08-05
 
@@ -78,6 +85,7 @@ Packaging only - the binary is identical to 0.1.0.
 - Tokens excluded from logs, toasts, and diagnostics
 - Browser open restricted to http(s) URLs
 
+[0.2.1]: https://github.com/Resetnak/cooldeck/releases/tag/v0.2.1
 [0.2.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.2.0
 [0.1.2]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.2
 [0.1.1]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.1

--- a/README.cs.md
+++ b/README.cs.md
@@ -253,7 +253,7 @@ curl -fsSL https://raw.githubusercontent.com/Resetnak/cooldeck/main/install.sh |
 ```
 
 Rozpozná platformu, **ověří kontrolní součet** a binárku uloží do `~/.local/bin`. Cíl přepíšete přes
-`COOLDECK_INSTALL_DIR`, konkrétní verzi vynutíte přes `COOLDECK_VERSION=v0.2.0`. Jestli se vám nechce
+`COOLDECK_INSTALL_DIR`, konkrétní verzi vynutíte přes `COOLDECK_VERSION=v0.2.1`. Jestli se vám nechce
 pouštět skript rovnou do shellu, [přečtěte si ho](install.sh) - je krátký.
 
 ### Varianta 3: Linuxové balíčky

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ curl -fsSL https://raw.githubusercontent.com/Resetnak/cooldeck/main/install.sh |
 ```
 
 Detects your platform, **verifies the checksum**, and drops the binary in `~/.local/bin`. Override
-with `COOLDECK_INSTALL_DIR`, or pin a version with `COOLDECK_VERSION=v0.2.0`. Read it first if you
+with `COOLDECK_INSTALL_DIR`, or pin a version with `COOLDECK_VERSION=v0.2.1`. Read it first if you
 would rather not pipe a script into a shell - [it is short](install.sh).
 
 ### Option 3: Linux packages

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #
 # Reads nothing, writes one binary, and verifies its checksum before doing so.
 # Override the destination with COOLDECK_INSTALL_DIR, or pin a version with
-# COOLDECK_VERSION=v0.2.0.
+# COOLDECK_VERSION=v0.2.1.
 #
 # POSIX sh on purpose: this has to run on a stock Alpine container as readily
 # as on a Mac.


### PR DESCRIPTION
Patch release for the fixes merged in #14.

- Changelog: `Unreleased` becomes `0.2.1`, with the new demo media and the security-limits note recorded alongside the four fixes.
- `COOLDECK_VERSION` examples in both READMEs and `install.sh` point at v0.2.1.

Tag `v0.2.1` goes on `main` once this merges; GoReleaser builds the archives, Linux packages, checksums and the Homebrew cask from it.