### PR TITLE
Make the docs tell the truth about what ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project uses [Semantic Versioning](https://semver.org/) once tagged
-releases begin.
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
 
 ## [0.2.1] - 2026-08-05
 
@@ -85,8 +86,9 @@ Packaging only - the binary is identical to 0.1.0.
 - Tokens excluded from logs, toasts, and diagnostics
 - Browser open restricted to http(s) URLs
 
-[0.2.1]: https://github.com/Resetnak/cooldeck/releases/tag/v0.2.1
-[0.2.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.2.0
-[0.1.2]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.2
-[0.1.1]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.1
+[Unreleased]: https://github.com/Resetnak/cooldeck/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/Resetnak/cooldeck/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/Resetnak/cooldeck/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/Resetnak/cooldeck/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/Resetnak/cooldeck/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Resetnak/cooldeck/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ and the full test matrix on ubuntu/macos/windows. `-race` is skipped on Windows.
 
 ## Architecture
 
-Layered so the same use cases can back the TUI, a CLI subcommand, or a future MCP adapter:
+Layered so the same use cases back the TUI, the MCP server, and any future CLI subcommand:
 
 ```
 cmd/cooldeck → internal/cli (cobra, flags, config load, service construction)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 CoolDeck contributors
+Copyright (c) 2026 Alexandr Rešetňak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.cs.md
+++ b/README.cs.md
@@ -37,7 +37,11 @@ z terminálu, který stejně máte otevřený.
 **Celé UI vyzkoušíte jedním řádkem - bez instance Coolify, bez tokenu, bez sítě:**
 
 ```bash
+# macOS (Homebrew)
 brew install resetnak/tap/cooldeck && cooldeck --demo
+
+# Linux a macOS (instalační skript)
+curl -fsSL https://raw.githubusercontent.com/Resetnak/cooldeck/main/install.sh | sh && cooldeck --demo
 ```
 
 Máte radši Go? `go install github.com/resetnak/cooldeck/cmd/cooldeck@latest`. Chcete binárku? Každé
@@ -207,6 +211,7 @@ odpovědi z překonaného požadavku se zahodí místo vykreslení.
 | `l` / `L` | Runtime logy / build log |
 | `b` / `o` | Otevřít doménu / repozitář v prohlížeči |
 | `c` | Zkopírovat UUID aplikace |
+| `Space` / `t` | Označit pro fleet tail / otevřít fleet tail |
 | `S` | Cyklovat řazení: stav → název → poslední deploy |
 | `R` | Ruční refresh |
 
@@ -221,7 +226,7 @@ odpovědi z překonaného požadavku se zahodí místo vykreslení.
 ### 📜 Logy
 | Zkratka | Akce |
 | :--- | :--- |
-| `Space` | Pauza / obnovení pollingu |
+| `Space` | Pauza / obnovení pollingu (v seznamu aplikací `Space` místo toho označuje pro fleet tail) |
 | `f` / `w` | Follow tail / zalamování dlouhých řádků |
 | `/` · `n` · `N` | Hledat · další nález · předchozí nález |
 | `c` | Zkopírovat buffer nebo aktuální nález |
@@ -237,14 +242,15 @@ Kompletní mapa: v aplikaci `?`, nebo [docs/keybindings.md](docs/keybindings.md)
 **Žádné runtime závislosti.** Každá varianta níž vám dá jednu statickou binárku; toolchain
 potřebuje jen build ze zdrojáků (Go **1.26.5+**, bez CGO).
 
-### Varianta 1: Homebrew (macOS a Linux)
+### Varianta 1: Homebrew (macOS)
 
 ```bash
 brew install resetnak/tap/cooldeck
 cooldeck --demo
 ```
 
-Aktualizace pak chodí přes `brew upgrade` jako u čehokoli jiného.
+Aktualizace pak chodí přes `brew upgrade` jako u čehokoli jiného. Tap publikuje cask, který Homebrew
+na Linuxu nepodporuje - na Linuxu použijte instalační skript níže.
 
 ### Varianta 2: Instalační skript (macOS a Linux)
 
@@ -297,8 +303,8 @@ binárce začnete věřit:
 shasum -a 256 -c checksums.txt --ignore-missing
 ```
 
-Archivy pro Linux, macOS a Windows (`amd64` & `arm64`) staví [GoReleaser](.goreleaser.yaml) z tagů
-`v*`.
+Archivy pro Linux a macOS (`amd64` & `arm64`) a Windows (`amd64`) staví
+[GoReleaser](.goreleaser.yaml) z tagů `v*`.
 
 ### Varianta 5: `go install`
 
@@ -454,9 +460,10 @@ make bench               # benchmarky vykreslování
 make vuln                # govulncheck
 ```
 
-Oba GIFy v tomto README jsou generované, ne ručně nahrané: `vhs cassette.tape` a `vhs outage.tape`
-znovu postaví binárku a nahrají záznam proti `--demo`, takže se nemůžou rozejít s pracovní kopií. Oba
-běží v jednorázovém `COOLDECK_CONFIG_DIR` pod `/tmp` a ničeho vašeho se nedotknou.
+Všechny čtyři GIFy v tomto README jsou generované, ne ručně nahrané: `vhs cassette.tape`,
+`vhs tail.tape`, `vhs mcp.tape` a `vhs outage.tape` znovu postaví binárku a nahrají záznam proti
+`--demo`, takže se nemůžou rozejít s pracovní kopií. Všechny běží v jednorázovém
+`COOLDECK_CONFIG_DIR` pod `/tmp` a ničeho vašeho se nedotknou.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ from the terminal you already have open.
 **Try the whole UI in one line - no Coolify instance, no token, no network:**
 
 ```bash
+# macOS (Homebrew)
 brew install resetnak/tap/cooldeck && cooldeck --demo
+
+# Linux & macOS (install script)
+curl -fsSL https://raw.githubusercontent.com/Resetnak/cooldeck/main/install.sh | sh && cooldeck --demo
 ```
 
 Prefer Go? `go install github.com/resetnak/cooldeck/cmd/cooldeck@latest`. Prefer a binary? Every
@@ -207,6 +211,7 @@ from a superseded request are dropped rather than rendered.
 | `l` / `L` | Runtime logs / build log |
 | `b` / `o` | Open primary domain / repository in the browser |
 | `c` | Copy application UUID |
+| `Space` / `t` | Mark for the fleet tail / open the fleet tail |
 | `S` | Cycle sort: status → name → last deploy |
 | `R` | Manual refresh |
 
@@ -221,7 +226,7 @@ from a superseded request are dropped rather than rendered.
 ### 📜 Logs
 | Shortcut | Action |
 | :--- | :--- |
-| `Space` | Pause / resume polling |
+| `Space` | Pause / resume polling (in the applications list, `Space` marks for the fleet tail instead) |
 | `f` / `w` | Follow tail / wrap long lines |
 | `/` · `n` · `N` | Search · next match · previous match |
 | `c` | Copy the buffer, or the current match |
@@ -237,14 +242,15 @@ Full map: press `?` in the app, or read [docs/keybindings.md](docs/keybindings.m
 **No runtime dependencies.** Every option below leaves you with a single static binary; only building
 from source needs a toolchain (Go **1.26.5+**, no CGO).
 
-### Option 1: Homebrew (macOS & Linux)
+### Option 1: Homebrew (macOS)
 
 ```bash
 brew install resetnak/tap/cooldeck
 cooldeck --demo
 ```
 
-Upgrades come with `brew upgrade` like anything else.
+Upgrades come with `brew upgrade` like anything else. The tap publishes a cask, which Homebrew on
+Linux does not support - on Linux, use the install script below.
 
 ### Option 2: Install script (macOS & Linux)
 
@@ -296,7 +302,7 @@ Windows ships as a `.zip`. Every release carries a `checksums.txt`; verify befor
 shasum -a 256 -c checksums.txt --ignore-missing
 ```
 
-Archives for Linux, macOS and Windows (`amd64` & `arm64`) are built by
+Archives for Linux and macOS (`amd64` & `arm64`) and Windows (`amd64`) are built by
 [GoReleaser](.goreleaser.yaml) from `v*` tags.
 
 ### Option 5: `go install`
@@ -452,9 +458,10 @@ make bench               # view rendering benchmarks
 make vuln                # govulncheck
 ```
 
-The two GIFs in this README are generated, not hand-recorded: `vhs cassette.tape` and
-`vhs outage.tape` rebuild the binary and re-record against `--demo`, so they cannot drift from the
-working tree. Both run in a throwaway `COOLDECK_CONFIG_DIR` under `/tmp` and touch nothing of yours.
+The four GIFs in this README are generated, not hand-recorded: `vhs cassette.tape`, `vhs tail.tape`,
+`vhs mcp.tape` and `vhs outage.tape` rebuild the binary and re-record against `--demo`, so they
+cannot drift from the working tree. All of them run in a throwaway `COOLDECK_CONFIG_DIR` under
+`/tmp` and touch nothing of yours.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,14 +15,20 @@ long-term support branch yet.
 
 Please **do not** open a public issue for exploitable security bugs.
 
-Email or message the repository maintainer privately with:
+Report privately through either channel:
+
+- [GitHub security advisory](https://github.com/Resetnak/cooldeck/security/advisories/new) (preferred)
+- Email the maintainer: <mail@resetnak.cz>
+
+Include:
 
 - description of the issue
 - impact (token leak, RCE via logs, path traversal, etc.)
 - reproduction steps or PoC
 - affected commit or version if known
 
-We will acknowledge the report and work on a fix before any public disclosure.
+You will get an acknowledgement within 72 hours, and a fix lands before any
+public disclosure.
 
 ## Non-vulnerabilities
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,8 @@
 # Architecture
 
-CoolDeck is layered so the same business logic can drive the TUI today and a
-CLI or MCP adapter later without rewriting Coolify integration.
+CoolDeck is layered so the same business logic drives the TUI and the MCP
+server today, and could back a non-interactive CLI without rewriting the
+Coolify integration.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐

--- a/docs/coolify-api.md
+++ b/docs/coolify-api.md
@@ -43,7 +43,7 @@ HTTP failures become `domain.Error` with a kind:
 | `unauthorized` | 401 - bad or missing token |
 | `forbidden` | 403 - token lacks permission (capability downgrade) |
 | `not_found` | 404 |
-| `rate_limit` | 429 |
+| `rate_limited` | 429 |
 | `cancelled` | context cancel (superseded request; usually silent) |
 | `decode` | unexpected JSON |
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+Decisions that shaped CoolDeck, in the order they were made. Each record states
+the context, the options considered, and why the chosen one won.
+
+| ADR | Decision |
+| :-- | :------- |
+| [0001](0001-use-go-and-charm-v2.md) | Use Go and Charm Bubble Tea v2 |
+| [0002](0002-direct-coolify-api-not-mcp.md) | Direct Coolify REST API, not MCP as transport |
+| [0003](0003-separate-domain-model-from-api-dto.md) | Separate domain model from API DTOs |
+| [0004](0004-credential-storage-strategy.md) | Credential storage strategy |
+| [0005](0005-tui-responsive-layout.md) | TUI responsive layout |
+| [0006](0006-mcp-server-read-only-by-default.md) | Ship an MCP server, read-only by default |
+| [0007](0007-fleet-tail-concurrency.md) | One request per tailed application, bounded by a shared sequence |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -116,7 +116,7 @@ one to ask, so the decision moves to the moment you add the flag. Some things wo
 deliberately:
 
 - **Scope the token, not just the flag.** The agent can do whatever the token can. Coolify has no
-  permission-introspection endpoint, so cooldeck assumes full capabilities and only learns otherwise
+  permission-introspection endpoint, so CoolDeck assumes full capabilities and only learns otherwise
   when a call is refused with a `403`. A token limited to the instance and scopes you are willing to
   automate is a real boundary; the flag alone is a smaller one.
 - **Prefer separate entries per instance.** Registering production read-only and staging with
@@ -148,10 +148,10 @@ Swap `--demo` for your real flags once you trust it.
 | Client reports the server failed to start | `command` is not on the client's `PATH`. Use the absolute path from `which cooldeck`. |
 | `no configuration file found` | The server loads the same config as the TUI. Run `cooldeck setup` first, or pass `--config`, or try `--demo`. |
 | Only six tools are listed | That is the read-only default. Add `--allow-mutations` to the launch command and restart the client - the tool list is sent once, at connection. |
-| A tool answers "Permission denied" | The token lacks that scope. The error carries Coolify's own suggestion; fix it in Coolify's *profile → API tokens* rather than in cooldeck. |
+| A tool answers "Permission denied" | The token lacks that scope. The error carries Coolify's own suggestion; fix it in Coolify's *profile → API tokens* rather than in CoolDeck. |
 | A tool answers "Request timed out" | Every call is bounded at 20 seconds, the same as in the TUI. A Coolify instance that slow will show the same symptom in the dashboard. |
 | Responses look truncated | The counts are capped (see the table above). Ask for a narrower window - a specific deployment's log rather than 2000 runtime lines. |
-| Garbled output or a client that cannot parse anything | Something wrote to stdout, which is the protocol transport. cooldeck writes diagnostics to stderr by design; a wrapper script that echoes to stdout will corrupt the session. |
+| Garbled output or a client that cannot parse anything | Something wrote to stdout, which is the protocol transport. CoolDeck writes diagnostics to stderr by design; a wrapper script that echoes to stdout will corrupt the session. |
 
 For anything else, `cooldeck mcp --help`, or the
 [troubleshooting guide](troubleshooting.md) for problems that are really about the Coolify

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,8 +19,7 @@ Symptoms: offline banner, “Cannot reach Coolify”, network error toast.
 | Actions greyed in palette | Capability downgraded after 403 | Check token scopes in Coolify |
 
 ```bash
-cooldeck auth status production
-echo "token set?" # never cat the secret into chat logs
+cooldeck auth status production   # reports whether a token exists; never prints it
 ```
 
 ## No applications
@@ -56,7 +55,7 @@ cooldeck --demo
 
 - Minimum usable size is about **60×18**.
 - Try `Ctrl+W` compact mode or a larger terminal.
-- ASCII glyph mode activates when the locale is not UTF-8; force via code path is automatic.
+- ASCII glyph mode activates automatically when the locale is not UTF-8; no flag is needed.
 
 ## Slow over SSH
 


### PR DESCRIPTION
First PR from the repo audit: documentation-only fixes, ordered by user impact.

## Why
- The headline `brew install` one-liner failed for every Linux user - the tap publishes a **cask**, which Homebrew on Linux does not support. Both READMEs now say macOS for Homebrew and give Linux the install-script line.
- SECURITY.md told reporters to "email the maintainer" without an address. It now links the GitHub advisory form and the maintainer email, with a 72h acknowledgement window.
- LICENSE said "CoolDeck contributors" while the README says "© Alexandr Rešetňak" - now one holder.

## Also
- CHANGELOG follows Keep a Changelog properly: `[Unreleased]` section, compare links, no "once tagged releases begin" hedge (five releases in).
- README: "two GIFs" → four, Windows `arm64` claim removed (not built), `space`/`t` added to the shortcut tables so the fleet tail is discoverable.
- `docs/architecture.md` + `CLAUDE.md` no longer call the shipped MCP server a "future adapter"; `docs/coolify-api.md` documents the real `rate_limited` error kind.
- New `docs/decisions/README.md` index; troubleshooting.md loses a filler snippet and a broken sentence; `docs/mcp.md` uses "CoolDeck" in prose.

Czech README mirrors every user-facing change.

## Verification
`make check` passes; all edited relative links resolve.