### PR TITLE
Harden the release pipeline and make local checks match CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-deps:
+        patterns: ['*']
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 ## Checks
 
-- [ ] `make check` passes (fmt, vet, tests, build)
+- [ ] `make check` passes (fmt, vet, lint, tests, build)
 - [ ] Golden snapshots reviewed, not just regenerated - an unexpected diff is usually a real regression
 - [ ] Keybindings, if any, are defined only in `internal/tui/keys.go`
 - [ ] Anything touching Coolify goes through `app.Service`, not straight to HTTP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +53,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -60,7 +62,7 @@ jobs:
           cache: true
       - uses: dominikh/staticcheck-action@v1
         with:
-          version: latest
+          version: "2026.1"
           install-go: false
       # Install with the job's Go toolchain so the linter matches go.mod (1.26+).
       # Prebuilt golangci-lint binaries lag and refuse newer language versions.
@@ -71,6 +73,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -91,6 +94,7 @@ jobs:
   build-matrix:
     name: Cross-build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,23 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      # This job runs with contents:write and a cross-repository PAT in its
+      # environment, so its actions are pinned to commit SHAs rather than
+      # mutable tags.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
-      - uses: goreleaser/goreleaser-action@v6
+      # A tag on a broken commit must not publish a release, a cask and three
+      # package formats without a single test having run.
+      - name: Test
+        run: go test ./...
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
   schedule:
     - cron: '17 4 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,7 +22,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Scan reachable vulnerabilities
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
   # Dependency review reads the dependency graph API, which private repositories
   # only get with GitHub Advanced Security. Without it the action fails the

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.tokensave/
 *.log
 .DS_Store
+coverage.out
+/.code-review-graph/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,13 +4,18 @@ project_name: cooldeck
 
 before:
   hooks:
-    - go mod tidy
+    # verify, not tidy: a release must build exactly the tagged tree. tidy can
+    # either mutate go.mod (releasing source that differs from the tag) or die
+    # on the resulting dirty state. CI keeps the module tidy on PRs instead.
+    - go mod verify
 
 builds:
   - main: ./cmd/cooldeck
     binary: cooldeck
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
     ignore:
@@ -58,11 +63,14 @@ release:
 # GITHUB_TOKEN cannot - hence HOMEBREW_TAP_GITHUB_TOKEN.
 homebrew_casks:
   - name: cooldeck
+    # A missing or expired tap token skips the cask push instead of failing the
+    # whole release - archives, checksums and packages still ship.
+    skip_upload: '{{ if envOrDefault "HOMEBREW_TAP_GITHUB_TOKEN" "" }}false{{ else }}true{{ end }}'
     repository:
       owner: Resetnak
       name: homebrew-tap
       branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      token: '{{ envOrDefault "HOMEBREW_TAP_GITHUB_TOKEN" "" }}'
     homepage: https://github.com/Resetnak/cooldeck
     description: Keyboard-first terminal dashboard for Coolify
     # Strip the quarantine flag Gatekeeper adds to downloaded archives, so the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ Single Go module, `github.com/resetnak/cooldeck`, Go 1.26.5+, no CGO.
 ## Commands
 
 ```bash
-make check               # fmt-check + vet + test + build - run before every PR
+make check               # fmt-check + vet + lint + test + build - run before every PR
 make build               # -> bin/cooldeck, injects version/commit/date ldflags
 make run                 # go run ./cmd/cooldeck --demo
 make test-race
 make test-update-golden  # UPDATE_GOLDEN=1 go test ./... - refresh TUI snapshots
-make lint                # staticcheck ./...
+make lint                # staticcheck + golangci-lint, pinned to the CI versions
 make bench               # benchmarks in internal/tui/views
 make vuln                # govulncheck
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BINARY := bin/cooldeck
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+# Strip the tag's leading v so local builds report the same shape as release
+# builds (goreleaser injects {{.Version}}, which has no v).
+VERSION ?= $(shell (git describe --tags --always --dirty 2>/dev/null || echo dev) | sed 's/^v//')
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w \
@@ -7,7 +9,7 @@ LDFLAGS := -s -w \
 	-X github.com/resetnak/cooldeck/internal/version.Commit=$(COMMIT) \
 	-X github.com/resetnak/cooldeck/internal/version.Date=$(DATE)
 
-.PHONY: build run test test-race test-update-golden lint fmt vet vuln check clean snapshot bench
+.PHONY: build run test test-race test-update-golden lint fmt fmt-check vet vuln check clean snapshot bench
 
 build:
 	mkdir -p bin
@@ -25,8 +27,11 @@ test-race:
 test-update-golden:
 	UPDATE_GOLDEN=1 go test ./...
 
+# The same linters CI runs, pinned to the same versions, via go run so a fresh
+# clone needs nothing preinstalled. v0.7.0 is staticcheck 2026.1.
 lint:
-	staticcheck ./...
+	go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --timeout=5m
 
 fmt:
 	gofmt -w $$(find . -name '*.go' -not -path './vendor/*')
@@ -38,7 +43,7 @@ vuln:
 	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
 # Pre-commit / CI local equivalent.
-check: fmt-check vet test build
+check: fmt-check vet lint test build
 
 fmt-check:
 	@test -z "$$(gofmt -l .)" || (echo "gofmt needed on:" && gofmt -l . && exit 1)

--- a/README.cs.md
+++ b/README.cs.md
@@ -445,11 +445,11 @@ vypustila ven.
 ### Vývoj
 
 ```bash
-make check               # fmt-check + vet + test + build - pusťte před každým PR
+make check               # fmt-check + vet + lint + test + build - pusťte před každým PR
 make run                 # go run ./cmd/cooldeck --demo
 make test-race
 make test-update-golden  # obnovit TUI snapshoty - a pak si *přečíst diff*
-make lint                # staticcheck
+make lint                # staticcheck + golangci-lint (stejné verze jako CI)
 make bench               # benchmarky vykreslování
 make vuln                # govulncheck
 ```

--- a/README.md
+++ b/README.md
@@ -443,11 +443,11 @@ shipping.
 ### Development
 
 ```bash
-make check               # fmt-check + vet + test + build - run this before every PR
+make check               # fmt-check + vet + lint + test + build - run this before every PR
 make run                 # go run ./cmd/cooldeck --demo
 make test-race
 make test-update-golden  # refresh the TUI snapshots, then *read the diff*
-make lint                # staticcheck
+make lint                # staticcheck + golangci-lint (same versions as CI)
 make bench               # view rendering benchmarks
 make vuln                # govulncheck
 ```

--- a/install.sh
+++ b/install.sh
@@ -30,10 +30,14 @@ need mktemp
 # curl or wget, whichever the machine happens to have.
 if command -v curl >/dev/null 2>&1; then
 	fetch() { curl -fsSL "$1" -o "$2"; }
-	fetch_stdout() { curl -fsSL "$1"; }
+	# Where does the URL redirect to? Follows the chain and prints the final URL.
+	resolve_url() { curl -fsSLI -o /dev/null -w '%{url_effective}' "$1"; }
 elif command -v wget >/dev/null 2>&1; then
 	fetch() { wget -qO "$2" "$1"; }
-	fetch_stdout() { wget -qO- "$1"; }
+	resolve_url() {
+		wget -q -S --max-redirect=0 -O /dev/null "$1" 2>&1 |
+			sed -n 's/^ *[Ll]ocation: *//p' | head -n 1
+	}
 else
 	fail "neither curl nor wget is installed"
 fi
@@ -52,12 +56,14 @@ esac
 
 version="${COOLDECK_VERSION:-}"
 if [ -z "$version" ]; then
-	# Follow the /latest redirect rather than parsing the API, so this needs no
-	# JSON tooling and no API token.
-	version=$(fetch_stdout "https://github.com/$REPO/releases/latest" 2>/dev/null |
-		sed -n 's|.*/releases/tag/\(v[0-9][^"]*\)".*|\1|p' | head -n 1)
+	# Follow the /latest redirect rather than scraping HTML or parsing the API:
+	# the redirect target is a stable contract, needs no JSON tooling, no token.
+	version=$( (resolve_url "https://github.com/$REPO/releases/latest" || true) |
+		sed -n 's|.*/releases/tag/\(v[0-9][^/?# ]*\).*|\1|p' | head -n 1)
 	[ -n "$version" ] || fail "could not determine the latest version; set COOLDECK_VERSION"
 fi
+# Accept COOLDECK_VERSION with or without the leading v.
+case "$version" in v*) ;; *) version="v$version" ;; esac
 
 archive="cooldeck_${version#v}_${os}_${arch}.tar.gz"
 base="https://github.com/$REPO/releases/download/$version"
@@ -70,7 +76,8 @@ fetch "$base/$archive" "$tmp/$archive" || fail "download failed: $base/$archive"
 fetch "$base/checksums.txt" "$tmp/checksums.txt" || fail "could not download checksums.txt"
 
 # Verify before trusting. A download that cannot be checked is not installed.
-expected=$(grep " $archive\$" "$tmp/checksums.txt" | cut -d' ' -f1)
+# awk matches the filename as a literal field, not a regex.
+expected=$(awk -v f="$archive" '$2 == f { print $1 }' "$tmp/checksums.txt")
 [ -n "$expected" ] || fail "$archive is not listed in checksums.txt"
 
 if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
Second PR from the repo audit: build/release/CI tooling.

## Release safety
- **Tests gate the release**: `release.yml` now runs `go test ./...` before `goreleaser release`. Previously a tag on a broken commit published a GitHub release, the Homebrew cask and three package formats with zero tests run.
- **`-trimpath` in released binaries** - they were the only builds in the project without it, so shipped panics embedded `/home/runner/...` paths.
- **`go mod verify` instead of `go mod tidy`** in the before hook: a release must build exactly the tagged tree; tidy could mutate it or die on the dirty state.
- **Missing/expired `HOMEBREW_TAP_GITHUB_TOKEN` no longer kills the whole release** - the cask push is skipped, archives/checksums/packages still ship (`skip_upload` template; `goreleaser check` passes).
- Release workflow actions pinned to commit SHAs (that job holds `contents:write` + a cross-repo PAT); `timeout-minutes` added.

## CI parity & hygiene
- `make lint` = the same pinned staticcheck (v0.7.0 / 2026.1) + golangci-lint v2.1.6 that CI runs, via `go run` so a fresh clone needs nothing on PATH. `make check` now includes it - green locally means green in CI. Docs updated (README en/cs, CLAUDE.md, PR template).
- Every CI/security job gets `timeout-minutes`; staticcheck-action and govulncheck pinned instead of `latest`; `workflow_dispatch` on security.yml for on-demand scans.
- New `.github/dependabot.yml` (gomod weekly, grouped + github-actions weekly).

## Consistency fixes
- Local builds report `0.2.1-N-g…` instead of `v0.2.1-N-g…`, matching goreleaser's un-prefixed `{{.Version}}`.
- `install.sh`: latest version comes from the `/releases/latest` redirect (a stable contract) rather than grepping the HTML page; `COOLDECK_VERSION=0.2.1` without the `v` now works; checksum lookup matches the filename literally via awk instead of as a regex.

## Verification
`make check` (incl. the new lint target) passes locally; `goreleaser check` validates; `sh -n install.sh` clean; redirect-based version resolution tested against the live repo (returns `v0.2.1`).