### PR TITLE
Fix the bugs the repo audit surfaced in config, coolify and the TUI

### DIFF
--- a/internal/app/demo/demo.go
+++ b/internal/app/demo/demo.go
@@ -181,11 +181,11 @@ func (s *Service) RuntimeLogs(ctx context.Context, appUUID string, lines int) (a
 		raw = append(append([]string(nil), raw...), s.tailLines(appUUID, elapsed)...)
 	}
 
-	parsed := domain.ParseLogPayload(strings.Join(raw, "\n"), lines)
+	parsed, truncated := domain.ParseLogPayload(strings.Join(raw, "\n"), lines)
 	return app.LogSnapshot{
 		Lines:     parsed,
 		LoadedAt:  s.now(),
-		Truncated: lines > 0 && len(raw) > lines,
+		Truncated: truncated,
 	}, nil
 }
 
@@ -363,7 +363,7 @@ func (s *Service) newDeployment(a *domain.Application, trigger string, force boo
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
-	d.Logs = domain.ParseLogPayload(buildLog(a.Name, d.CommitSHA, domain.DeploymentQueued), 0)
+	d.Logs, _ = domain.ParseLogPayload(buildLog(a.Name, d.CommitSHA, domain.DeploymentQueued), 0)
 	return d
 }
 

--- a/internal/app/demo/fixtures.go
+++ b/internal/app/demo/fixtures.go
@@ -204,7 +204,7 @@ func (s *Service) generateDeployments(
 			d.FinishedAt = &finished
 			d.UpdatedAt = finished
 		}
-		d.Logs = domain.ParseLogPayload(buildLog(a.Name, d.CommitSHA, status), 0)
+		d.Logs, _ = domain.ParseLogPayload(buildLog(a.Name, d.CommitSHA, status), 0)
 		deps = append(deps, d)
 
 		age += time.Duration(6+r.Intn(60)) * time.Hour

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -80,7 +80,7 @@ func newAuthStatusCommand(opts *options) *cobra.Command {
 		Short: "Show credential availability without revealing tokens",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load(opts.configPath)
+			cfg, err := loadConfig(opts.configPath)
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func newAuthStatusCommand(opts *options) *cobra.Command {
 }
 
 func loadInstance(path, id string) (config.Instance, error) {
-	cfg, err := config.Load(path)
+	cfg, err := loadConfig(path)
 	if err != nil {
 		return config.Instance{}, err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -137,10 +137,22 @@ func runTUI(ctx context.Context, opts *options) error {
 	return tui.Run(ctx, tuiOpts)
 }
 
+// loadConfig loads the file but tolerates unknown keys, honouring
+// config.Load's contract that the parsed Config stays usable. Reporting the
+// stray keys is `cooldeck config validate`'s job, not a reason to refuse to
+// start.
+func loadConfig(path string) (config.Config, error) {
+	cfg, err := config.Load(path)
+	if err != nil && !errors.Is(err, config.ErrUnknownKeys) {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
 // openConfiguredService resolves credentials and builds a Coolify service for
 // an instance ID. Used for mid-session switches from the TUI.
 func openConfiguredService(ctx context.Context, configPath, instanceID string) (app.Service, string, error) {
-	cfg, err := config.Load(configPath)
+	cfg, err := loadConfig(configPath)
 	if err != nil {
 		return nil, "", err
 	}
@@ -166,7 +178,7 @@ func resolveService(ctx context.Context, opts *options) (config.Config, app.Serv
 		return cfg, service, "Demo", nil
 	}
 
-	cfg, err := config.Load(opts.configPath)
+	cfg, err := loadConfig(opts.configPath)
 	if err != nil {
 		if errors.Is(err, config.ErrNotFound) {
 			return config.Config{}, nil, "", fmt.Errorf("%w; run with --demo or create %s", err, config.FileName)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,6 +347,17 @@ func (c Config) EffectiveRefreshInterval(inst Instance) time.Duration {
 	return d
 }
 
+// EffectiveLogRefreshInterval returns the log poll interval with the same kind
+// of floor as EffectiveRefreshInterval: an explicit "0s" would otherwise turn
+// tea.Tick into a hot loop against the API.
+func (c Config) EffectiveLogRefreshInterval() time.Duration {
+	d := time.Duration(c.LogRefreshInterval)
+	if d < time.Second {
+		return DefaultLogRefreshInterval
+	}
+	return d
+}
+
 func formatKeys(keys []toml.Key) string {
 	out := make([]string, 0, len(keys))
 	for _, k := range keys {

--- a/internal/coolify/mapping.go
+++ b/internal/coolify/mapping.go
@@ -55,7 +55,9 @@ func mapDeployment(dto deploymentDTO) domain.Deployment {
 		StartedAt:       created,
 		CreatedAt:       created,
 		UpdatedAt:       updated,
-		Logs:            parseDeploymentLogs(dto.Logs),
+		// Logs stay unparsed here on purpose: list endpoints carry the full
+		// build log of every deployment, and nothing reads it from a list.
+		// DeploymentLogs parses the one deployment actually opened.
 	}
 	if !deployment.Status.IsActive() && !updated.IsZero() {
 		deployment.FinishedAt = &updated
@@ -80,7 +82,8 @@ func parseDeploymentLogs(raw string) []domain.LogLine {
 	}
 	items := []deploymentLogDTO{}
 	if err := json.Unmarshal([]byte(raw), &items); err != nil {
-		return domain.ParseLogPayload(raw, 20_000)
+		lines, _ := domain.ParseLogPayload(raw, 20_000)
+		return lines
 	}
 	lines := make([]domain.LogLine, 0, len(items))
 	for _, item := range items {

--- a/internal/coolify/service.go
+++ b/internal/coolify/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -125,7 +126,14 @@ func (s *Service) ApplicationDetail(ctx context.Context, appUUID string) (app.Ap
 	if err := s.client.getJSON(ctx, "applications/"+url.PathEscape(appUUID), nil, &dto); err != nil {
 		return app.ApplicationDetail{}, domain.AsError(err).WithOperation("get application")
 	}
-	deployments, _ := s.Deployments(ctx, appUUID, 10)
+	deployments, deployErr := s.Deployments(ctx, appUUID, 10)
+	if deployErr != nil {
+		// The detail is still worth rendering without its history, but a 403
+		// must downgrade the capability like everywhere else - silence here
+		// would render "no deployments" for a permissions problem.
+		s.downgradeForError(deployErr, "deployments")
+		deployments = nil
+	}
 	application := mapApplication(dto)
 	if len(deployments) > 0 {
 		summary := deployments[0].Summary(s.now())
@@ -141,7 +149,8 @@ func (s *Service) RuntimeLogs(ctx context.Context, appUUID string, lines int) (a
 		s.downgradeForError(err, "application_logs")
 		return app.LogSnapshot{}, domain.AsError(err).WithOperation("get application logs")
 	}
-	return app.LogSnapshot{Lines: domain.ParseLogPayload(dto.Logs, lines), LoadedAt: s.now()}, nil
+	parsed, truncated := domain.ParseLogPayload(dto.Logs, lines)
+	return app.LogSnapshot{Lines: parsed, LoadedAt: s.now(), Truncated: truncated}, nil
 }
 
 func (s *Service) Deployments(ctx context.Context, appUUID string, limit int) ([]domain.Deployment, error) {
@@ -236,6 +245,11 @@ func mapDeployments(dtos []deploymentDTO) []domain.Deployment {
 	for _, dto := range dtos {
 		deployments = append(deployments, mapDeployment(dto))
 	}
+	// splitDeployments and attachDeployments assume newest first; enforce it
+	// here instead of trusting the API's ordering.
+	sort.SliceStable(deployments, func(i, j int) bool {
+		return deployments[i].CreatedAt.After(deployments[j].CreatedAt)
+	})
 	return deployments
 }
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -107,7 +107,8 @@ func AsError(err error) *Error {
 	return e
 }
 
-// Is lets callers match on kind with errors.Is(err, domain.ErrorForbidden).
+// Is makes two domain errors match under errors.Is when their kinds are
+// equal. To branch on a kind directly, use IsKind.
 func (e *Error) Is(target error) bool {
 	var t *Error
 	if errors.As(target, &t) {
@@ -178,7 +179,7 @@ func defaultCopy(kind ErrorKind) (title, message, suggestion string, retryable b
 	case ErrorDecode:
 		return "Unexpected response",
 			"The response from Coolify could not be understood.",
-			"This usually means the Coolify version is not supported. Run `cooldeck doctor`.",
+			"This usually means the Coolify version is not supported. Check `cooldeck version` against the compatibility notes.",
 			false
 	case ErrorUnsupported:
 		return "Not supported",

--- a/internal/domain/logs.go
+++ b/internal/domain/logs.go
@@ -127,10 +127,11 @@ func ParseLogLine(raw string) LogLine {
 }
 
 // ParseLogPayload splits a raw multi-line log blob into sanitised lines,
-// keeping at most maxLines of the newest output.
-func ParseLogPayload(payload string, maxLines int) []LogLine {
+// keeping at most maxLines of the newest output. truncated reports whether
+// older lines were dropped to respect the limit.
+func ParseLogPayload(payload string, maxLines int) (lines []LogLine, truncated bool) {
 	if payload == "" {
-		return nil
+		return nil, false
 	}
 	raw := strings.Split(strings.ReplaceAll(payload, "\r\n", "\n"), "\n")
 	// Drop the trailing empty element produced by a final newline.
@@ -139,13 +140,14 @@ func ParseLogPayload(payload string, maxLines int) []LogLine {
 	}
 	if maxLines > 0 && len(raw) > maxLines {
 		raw = raw[len(raw)-maxLines:]
+		truncated = true
 	}
 
-	lines := make([]LogLine, 0, len(raw))
+	lines = make([]LogLine, 0, len(raw))
 	for _, r := range raw {
 		lines = append(lines, ParseLogLine(r))
 	}
-	return lines
+	return lines, truncated
 }
 
 // DetectLogLevel finds a severity token anywhere in the line. It is format

--- a/internal/domain/logs_test.go
+++ b/internal/domain/logs_test.go
@@ -114,7 +114,10 @@ func TestParseLogPayloadKeepsNewestLines(t *testing.T) {
 		b.WriteString(string(rune('0' + i%10)))
 		b.WriteByte('\n')
 	}
-	lines := ParseLogPayload(b.String(), 10)
+	lines, truncated := ParseLogPayload(b.String(), 10)
+	if !truncated {
+		t.Error("dropping 90 of 100 lines must report truncated")
+	}
 	if len(lines) != 10 {
 		t.Fatalf("got %d lines, want 10", len(lines))
 	}
@@ -123,15 +126,15 @@ func TestParseLogPayloadKeepsNewestLines(t *testing.T) {
 		t.Errorf("last line = %q, want %q", lines[9].Text, "line 9")
 	}
 
-	if got := ParseLogPayload("", 10); got != nil {
+	if got, _ := ParseLogPayload("", 10); got != nil {
 		t.Errorf("empty payload should yield nil, got %v", got)
 	}
 	// A trailing newline must not produce a phantom blank line.
-	if got := ParseLogPayload("one\ntwo\n", 0); len(got) != 2 {
+	if got, _ := ParseLogPayload("one\ntwo\n", 0); len(got) != 2 {
 		t.Errorf("got %d lines, want 2", len(got))
 	}
 	// CRLF payloads are normalised.
-	if got := ParseLogPayload("one\r\ntwo\r\n", 0); len(got) != 2 || got[0].Text != "one" {
+	if got, _ := ParseLogPayload("one\r\ntwo\r\n", 0); len(got) != 2 || got[0].Text != "one" {
 		t.Errorf("CRLF payload = %+v", got)
 	}
 }

--- a/internal/platform/browser.go
+++ b/internal/platform/browser.go
@@ -36,9 +36,13 @@ func OpenURL(rawURL string) error {
 	if name == "" {
 		return fmt.Errorf("no way to open a browser on %s", runtime.GOOS)
 	}
-	if err := exec.Command(name, args...).Start(); err != nil {
+	cmd := exec.Command(name, args...)
+	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("open browser: %w", err)
 	}
+	// Reap the opener once it exits; Start without Wait leaves a zombie per
+	// opened link for the lifetime of the session.
+	go func() { _ = cmd.Wait() }()
 	return nil
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -161,7 +161,7 @@ func (m *Model) cancelDeploymentLogsRequest() {
 }
 
 func (m *Model) runtimeLogsTick(appUUID string) tea.Cmd {
-	interval := time.Duration(m.opts.Config.LogRefreshInterval)
+	interval := m.opts.Config.EffectiveLogRefreshInterval()
 	return tea.Tick(interval, func(time.Time) tea.Msg {
 		return runtimeLogsTickMsg{AppUUID: appUUID}
 	})

--- a/internal/tui/instance_form.go
+++ b/internal/tui/instance_form.go
@@ -257,70 +257,93 @@ func (m *Model) submitInstanceForm() tea.Cmd {
 	}
 	inst := f.toInstance()
 
+	// Build the new config on a copied map so nothing changes on the model
+	// until the write succeeds.
+	cfg := m.opts.Config
+	cfg.Instances = cloneInstances(cfg.Instances)
 	if f.mode == instanceFormAdd {
-		if m.opts.Config.Instances == nil {
-			m.opts.Config.Instances = map[string]config.Instance{}
-		}
-		if _, exists := m.opts.Config.Instances[inst.ID]; exists {
+		if _, exists := cfg.Instances[inst.ID]; exists {
 			f.err = "an instance with this id already exists"
 			return nil
 		}
-		// Persist token before config so a failed keyring write does not leave
-		// a config pointing at a missing secret.
-		if m.opts.StoreCredentials != nil {
-			if err := m.opts.StoreCredentials(inst, strings.TrimSpace(f.token)); err != nil {
-				f.err = "store token: " + err.Error()
-				return nil
-			}
-		} else {
-			// Fallback: store via credentials package directly when wired without callback.
-			if err := credentials.Store(credentials.KeyFor(inst), credentials.NewToken(strings.TrimSpace(f.token))); err != nil {
-				f.err = "store token: " + err.Error()
-				return nil
-			}
-		}
-		m.opts.Config.Instances[inst.ID] = inst
-		if m.opts.Config.DefaultInstance == "" {
-			m.opts.Config.DefaultInstance = inst.ID
+		cfg.Instances[inst.ID] = inst
+		if cfg.DefaultInstance == "" {
+			cfg.DefaultInstance = inst.ID
 		}
 	} else {
-		existing, err := m.opts.Config.Instance(inst.ID)
+		existing, err := cfg.Instance(inst.ID)
 		if err != nil {
 			f.err = err.Error()
 			return nil
 		}
 		existing.Name = inst.Name
 		existing.URL = inst.URL
-		m.opts.Config.Instances[inst.ID] = existing
+		cfg.Instances[inst.ID] = existing
 	}
 
-	if err := m.opts.SaveConfig(m.opts.Config); err != nil {
-		f.err = "save config: " + err.Error()
-		// Best effort: remove the instance we just added if save failed.
-		if f.mode == instanceFormAdd {
-			delete(m.opts.Config.Instances, inst.ID)
+	// Keyring and disk writes run inside the command, never on the event
+	// loop: a macOS Keychain prompt can block for seconds, and the UI -
+	// including ctrl+c - would freeze with it. f.saving keeps the form inert
+	// until the result message lands.
+	f.saving = true
+	store := m.opts.StoreCredentials
+	save := m.opts.SaveConfig
+	token := strings.TrimSpace(f.token)
+	mode := f.mode
+	return func() tea.Msg {
+		if mode == instanceFormAdd {
+			// Persist token before config so a failed keyring write does not
+			// leave a config pointing at a missing secret.
+			var err error
+			if store != nil {
+				err = store(inst, token)
+			} else {
+				// Fallback: store directly when wired without a callback.
+				err = credentials.Store(credentials.KeyFor(inst), credentials.NewToken(token))
+			}
+			if err != nil {
+				return instanceFormSavedMsg{Err: fmt.Errorf("store token: %w", err)}
+			}
+		}
+		if save != nil {
+			if err := save(cfg); err != nil {
+				return instanceFormSavedMsg{Err: fmt.Errorf("save config: %w", err)}
+			}
+		}
+		return instanceFormSavedMsg{Config: cfg, Instance: inst, Mode: mode}
+	}
+}
+
+// applyInstanceFormSaved commits or reports the result of the asynchronous
+// form submission.
+func (m *Model) applyInstanceFormSaved(msg instanceFormSavedMsg) tea.Cmd {
+	f := m.instanceForm
+	if msg.Err != nil {
+		if f != nil {
+			f.saving = false
+			f.err = msg.Err.Error()
 		}
 		return nil
 	}
 
-	name := inst.Name
-	id := inst.ID
-	mode := f.mode
+	m.opts.Config = msg.Config
+	name := msg.Instance.Name
+	id := msg.Instance.ID
 	m.closeInstanceForm()
 	m.refreshInstances()
 	m.refreshDiagnostics()
 
-	if mode == instanceFormAdd && m.opts.OpenService != nil {
+	if msg.Mode == instanceFormAdd && m.opts.OpenService != nil {
 		return tea.Batch(
 			m.pushToast(components.ToastSuccess, "Instance added", name),
 			m.switchInstance(id),
 		)
 	}
-	msg := "Instance updated"
-	if mode == instanceFormAdd {
-		msg = "Instance added"
+	text := "Instance updated"
+	if msg.Mode == instanceFormAdd {
+		text = "Instance added"
 	}
-	return m.pushToast(components.ToastSuccess, msg, name)
+	return m.pushToast(components.ToastSuccess, text, name)
 }
 
 func (m *Model) renderInstanceForm() string {

--- a/internal/tui/instance_form_test.go
+++ b/internal/tui/instance_form_test.go
@@ -63,7 +63,20 @@ func TestAddInstanceFormValidatesAndSaves(t *testing.T) {
 	model.handleInstanceFormKey(tea.KeyPressMsg{Code: tea.KeyTab})
 	typeIn("secret-token")
 
+	// The writes run inside the returned command; deliver its result message
+	// back to the model, as the event loop would.
 	cmd := model.submitInstanceForm()
+	if cmd == nil {
+		t.Fatalf("expected a save command, form err: %s", model.instanceForm.err)
+	}
+	if !model.instanceForm.saving {
+		t.Fatal("form should be inert while saving")
+	}
+	saveMsg, ok := cmd().(instanceFormSavedMsg)
+	if !ok {
+		t.Fatal("expected instanceFormSavedMsg")
+	}
+	toastCmd := model.applyInstanceFormSaved(saveMsg)
 	if model.instanceForm != nil {
 		t.Fatalf("form still open: %s", model.instanceForm.err)
 	}
@@ -73,11 +86,13 @@ func TestAddInstanceFormValidatesAndSaves(t *testing.T) {
 	if got := saved.Instances["staging"]; got.URL != "https://coolify.example.com" || got.Name != "Staging EU" {
 		t.Fatalf("saved instance = %#v", got)
 	}
-	if cmd == nil {
+	if got := model.opts.Config.Instances["staging"]; got.URL != "https://coolify.example.com" {
+		t.Fatalf("config not committed to model: %#v", got)
+	}
+	if toastCmd == nil {
 		t.Fatal("expected success toast")
 	}
-	// Toast cmd.
-	if msg := cmd(); msg != nil {
+	if msg := toastCmd(); msg != nil {
 		if toast, ok := msg.(toastMsg); ok && toast.Kind != int(components.ToastSuccess) {
 			t.Fatalf("toast = %+v", toast)
 		}
@@ -107,7 +122,11 @@ func TestEditInstanceFormUpdatesNameURL(t *testing.T) {
 	}
 	model.instanceForm.name = "Production"
 	model.instanceForm.url = "https://new.example"
-	model.submitInstanceForm()
+	cmd := model.submitInstanceForm()
+	if cmd == nil {
+		t.Fatalf("expected a save command, form err: %s", model.instanceForm.err)
+	}
+	model.applyInstanceFormSaved(cmd().(instanceFormSavedMsg))
 	if saved.Instances["prod"].Name != "Production" || saved.Instances["prod"].URL != "https://new.example" {
 		t.Fatalf("saved = %#v", saved.Instances["prod"])
 	}

--- a/internal/tui/instance_switch.go
+++ b/internal/tui/instance_switch.go
@@ -90,7 +90,12 @@ func (m *Model) applyInstanceSwitchFailed(msg instanceSwitchFailedMsg) tea.Cmd {
 	m.rememberError(msg.Err)
 	m.refreshInstances()
 	m.refreshDiagnostics()
-	return m.pushToast(components.ToastError, "Could not switch instance", msg.Err.Message)
+	detail := msg.Err.Message
+	if detail == "" {
+		// A wrapped non-domain error lands in Detail; never show a blank toast.
+		detail = msg.Err.Detail
+	}
+	return m.pushToast(components.ToastError, "Could not switch instance", detail)
 }
 
 // runDeleteInstance removes a local config entry and optionally its keyring token.
@@ -110,27 +115,13 @@ func (m *Model) runDeleteInstance(action pendingAction) tea.Cmd {
 	if err := m.opts.Config.RemoveInstance(id); err != nil {
 		return m.pushToast(components.ToastError, "Delete failed", err.Error())
 	}
-	if m.opts.SaveConfig != nil {
-		if err := m.opts.SaveConfig(m.opts.Config); err != nil {
-			m.opts.Config.Instances = prevInstances
-			m.opts.Config.DefaultInstance = prevDefault
-			return m.pushToast(components.ToastError, "Could not write config", err.Error())
-		}
-	}
-	if m.opts.RemoveCredentials != nil {
-		if err := m.opts.RemoveCredentials(inst); err != nil {
-			m.refreshInstances()
-			return m.pushToast(components.ToastWarning,
-				"Instance removed, credential cleanup failed", err.Error())
-		}
-	}
 
 	m.refreshInstances()
 	m.refreshDiagnostics()
 
-	// Defer the follow-up (toast + optional switch) to a message so switchInstance
-	// is not started while building a tea.Batch - that would set operationInFlight
-	// before the event loop runs the command.
+	// The follow-up (toast + optional switch) is deferred to a message so
+	// switchInstance is not started while building a tea.Batch - that would
+	// set operationInFlight before the event loop runs the command.
 	next := ""
 	empty := false
 	if wasActive {
@@ -143,9 +134,27 @@ func (m *Model) runDeleteInstance(action pendingAction) tea.Cmd {
 			}
 		}
 	}
+
+	// Disk and keyring writes run inside the command, never on the event
+	// loop: a macOS Keychain prompt can block for seconds, and the UI -
+	// including ctrl+c - would freeze with it.
+	save := m.opts.SaveConfig
+	removeCreds := m.opts.RemoveCredentials
+	cfg := m.opts.Config
 	name := action.instanceName
 	return func() tea.Msg {
-		return instanceRemovedMsg{Name: name, NextID: next, EmptyFleet: empty}
+		if save != nil {
+			if err := save(cfg); err != nil {
+				return instanceDeleteFailedMsg{Err: err, PrevDefault: prevDefault, PrevInstances: prevInstances}
+			}
+		}
+		credWarning := ""
+		if removeCreds != nil {
+			if err := removeCreds(inst); err != nil {
+				credWarning = err.Error()
+			}
+		}
+		return instanceRemovedMsg{Name: name, NextID: next, EmptyFleet: empty, CredWarning: credWarning}
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/resetnak/cooldeck/internal/app"
+	"github.com/resetnak/cooldeck/internal/config"
 	"github.com/resetnak/cooldeck/internal/domain"
 )
 
@@ -141,4 +142,25 @@ type instanceRemovedMsg struct {
 	NextID string
 	// EmptyFleet is true when no configured instances remain.
 	EmptyFleet bool
+	// CredWarning carries a keyring cleanup failure; the instance is gone
+	// from config either way.
+	CredWarning string
+}
+
+// instanceFormSavedMsg is delivered when the instance form's credential and
+// config writes finish. On success Config carries the committed config.
+type instanceFormSavedMsg struct {
+	Err      error
+	Config   config.Config
+	Instance config.Instance
+	Mode     instanceFormMode
+}
+
+// instanceDeleteFailedMsg is delivered when the config file could not be
+// written after a delete. It carries the snapshot to roll the in-memory
+// config back to.
+type instanceDeleteFailedMsg struct {
+	Err           error
+	PrevDefault   string
+	PrevInstances map[string]config.Instance
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -511,23 +511,39 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case instanceSwitchFailedMsg:
 		return m, m.applyInstanceSwitchFailed(msg)
 
+	case instanceFormSavedMsg:
+		return m, m.applyInstanceFormSaved(msg)
+
 	case instanceRemovedMsg:
-		if msg.EmptyFleet {
+		cmds := []tea.Cmd{}
+		if msg.CredWarning != "" {
+			cmds = append(cmds, m.pushToast(components.ToastWarning,
+				"Credential cleanup failed", msg.CredWarning))
+		}
+		switch {
+		case msg.EmptyFleet:
 			m.apps = views.NewApplications()
 			m.deployments = views.NewDeployments()
 			m.connection = components.ConnectionOffline
 			m.loading = false
-			return m, m.pushToast(components.ToastSuccess, "Instance removed",
-				"No instances remain. Run cooldeck setup to add one.")
-		}
-		if msg.NextID != "" {
-			return m, tea.Batch(
+			cmds = append(cmds, m.pushToast(components.ToastSuccess, "Instance removed",
+				"No instances remain. Run cooldeck setup to add one."))
+		case msg.NextID != "":
+			cmds = append(cmds,
 				m.pushToast(components.ToastSuccess, "Instance removed", msg.Name),
-				m.switchInstance(msg.NextID),
-			)
+				m.switchInstance(msg.NextID))
+		default:
+			cmds = append(cmds, m.pushToast(components.ToastSuccess, "Instance removed",
+				msg.Name+" deleted from local config"))
 		}
-		return m, m.pushToast(components.ToastSuccess, "Instance removed",
-			msg.Name+" deleted from local config")
+		return m, tea.Batch(cmds...)
+
+	case instanceDeleteFailedMsg:
+		m.opts.Config.Instances = msg.PrevInstances
+		m.opts.Config.DefaultInstance = msg.PrevDefault
+		m.refreshInstances()
+		m.refreshDiagnostics()
+		return m, m.pushToast(components.ToastError, "Could not write config", msg.Err.Error())
 	}
 
 	return m, nil

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -856,8 +856,12 @@ func (m *Model) handleTailSearchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// resumeTail re-arms every source after a pause.
+// resumeTail re-arms every source after a pause. Bumping the sequence first
+// orphans any tick scheduled before the pause - without it, a pending tick
+// fires alongside the fresh ones and every pause/resume cycle doubles the
+// polling rate.
 func (m *Model) resumeTail() tea.Cmd {
+	m.tailSeq++
 	uuids := m.tail.UUIDs()
 	cmds := make([]tea.Cmd, 0, len(uuids))
 	for i, uuid := range uuids {


### PR DESCRIPTION
Third PR from the repo audit: correctness fixes, ranked by user impact in the audit.

## Startup & config
- **A typo in config.toml made the app unstartable.** `config.Load` deliberately returns a usable config alongside `ErrUnknownKeys`, but only 2 of 5 call sites honoured that - the TUI, `cooldeck mcp` and `auth` all refused to start. One lenient loader now serves them all; `cooldeck config validate` remains the place that reports stray keys.
- `log_refresh_interval = "0s"` passed validation and turned `tea.Tick` into a hot loop against the API. The effective interval now has a floor, like the dashboard interval always had.

## Event-loop hygiene
- **Keyring writes ran synchronously inside `Update`** (instance form submit, instance delete). On macOS a Keychain prompt blocks for seconds and froze the whole UI, including `ctrl+c` - the one violation of the project's "all work happens in tea.Cmd goroutines" rule. Both paths now do disk + keyring work in a command and commit state when the result message lands; rollback on a failed config write moved with it.
- `resumeTail` now bumps `tailSeq`, so a tick scheduled before the pause is orphaned instead of starting a second polling chain - previously every pause/resume cycle could double the request rate.
- `platform.OpenURL` reaps the opener process (`Start` without `Wait` left a zombie per opened link).

## Coolify service
- `ApplicationDetail` swallowed the deployments error entirely (`deployments, _ :=`); a 403 rendered as "no deployments". It now downgrades the capability like `Dashboard` does.
- `LogSnapshot.Truncated` was only ever set by the demo service; real instances never showed the "older lines dropped" indicator. `ParseLogPayload` now reports truncation and the coolify service passes it through.
- `attachDeployments`/`splitDeployments` assumed the API returns deployments newest-first; the sort is now enforced after mapping.
- The dashboard refresh parsed the **full build log of every deployment in the fleet** (up to 20k regex-scanned lines each) on every poll, then never read them. Lists skip log parsing; `DeploymentLogs` parses the one deployment actually opened.

## Small ones
- Instance-switch failure toast could be empty for non-domain errors; it falls back to the error detail. Failed keyring cleanup after a delete surfaces as a warning toast instead of vanishing.
- `domain.Error.Is` doc no longer claims an `errors.Is` call that would not compile; the decode-error suggestion no longer references a `cooldeck doctor` command that does not exist.

## Verification
`make check` (fmt, vet, staticcheck + golangci-lint, tests, build) passes; the form tests now exercise the async submit path explicitly, including the inert-while-saving state and model commit.