### PR TITLE
Explain state-dependent 400s and stop downgrading capabilities on 404

### DIFF
--- a/internal/coolify/client_test.go
+++ b/internal/coolify/client_test.go
@@ -139,6 +139,45 @@ func TestDeploymentLogsAreSanitized(t *testing.T) {
 	}
 }
 
+func TestValidationErrorsGetStateAwareCopy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Application is not running."}`, http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	service := newTestService(t, server, time.Now())
+	_, err := service.RuntimeLogs(context.Background(), "app-1", 100)
+	derr := domain.AsError(err)
+	if derr.Kind != domain.ErrorValidation || derr.Title != "Runtime logs unavailable" || derr.Suggestion == "" {
+		t.Fatalf("runtime logs copy not rewritten: %#v", derr)
+	}
+
+	_, err = service.Restart(context.Background(), "app-1")
+	derr = domain.AsError(err)
+	if derr.Kind != domain.ErrorValidation || !strings.Contains(derr.Title, "restart") || derr.Suggestion == "" {
+		t.Fatalf("restart copy not rewritten: %#v", derr)
+	}
+}
+
+func TestNotFoundDoesNotDowngradeCapabilities(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	service := newTestService(t, server, time.Now())
+	if _, err := service.RuntimeLogs(context.Background(), "deleted-app", 100); !domain.IsKind(err, domain.ErrorNotFound) {
+		t.Fatalf("error = %v", err)
+	}
+	if _, err := service.Restart(context.Background(), "deleted-app"); !domain.IsKind(err, domain.ErrorNotFound) {
+		t.Fatalf("error = %v", err)
+	}
+	caps := service.Capabilities()
+	if !caps.ApplicationLogs || !caps.Restart {
+		t.Fatalf("stale resource downgraded capabilities: %#v", caps)
+	}
+}
+
 func newTestService(t *testing.T, server *httptest.Server, now time.Time) *Service {
 	t.Helper()
 	service, err := New(Options{

--- a/internal/coolify/service.go
+++ b/internal/coolify/service.go
@@ -147,7 +147,16 @@ func (s *Service) RuntimeLogs(ctx context.Context, appUUID string, lines int) (a
 	dto := logsDTO{}
 	if err := s.client.getJSON(ctx, "applications/"+url.PathEscape(appUUID)+"/logs", query, &dto); err != nil {
 		s.downgradeForError(err, "application_logs")
-		return app.LogSnapshot{}, domain.AsError(err).WithOperation("get application logs")
+		derr := domain.AsError(err).WithOperation("get application logs")
+		if derr.Kind == domain.ErrorValidation {
+			// Coolify answers 400 when there is no running container to read
+			// from - mid-deploy, stopped and crashed applications all land
+			// here, so the generic "request invalid" copy would mislead.
+			derr.Title = "Runtime logs unavailable"
+			derr.Message = "The application has no running container to read logs from."
+			derr.Suggestion = "Follow the deployment log while a deployment is in progress; runtime logs return once the application is running."
+		}
+		return app.LogSnapshot{}, derr
 	}
 	parsed, truncated := domain.ParseLogPayload(dto.Logs, lines)
 	return app.LogSnapshot{Lines: parsed, LoadedAt: s.now(), Truncated: truncated}, nil
@@ -209,7 +218,16 @@ func (s *Service) mutate(ctx context.Context, appUUID, operation string) (app.Op
 	path := fmt.Sprintf("applications/%s/%s", url.PathEscape(appUUID), operation)
 	if err := s.client.postJSON(ctx, path, nil, &dto); err != nil {
 		s.downgradeForError(err, operation)
-		return app.OperationResult{}, domain.AsError(err).WithOperation(operation + " application")
+		derr := domain.AsError(err).WithOperation(operation + " application")
+		if derr.Kind == domain.ErrorValidation {
+			// A 400 on a lifecycle endpoint means the application is not in a
+			// state that accepts the operation (restart while stopped, stop
+			// while already stopped, ...), not that the request was malformed.
+			derr.Title = "Cannot " + operation + " in the current state"
+			derr.Message = "Coolify refused because the application is not in a state that allows " + operation + "."
+			derr.Suggestion = "Press R to refresh the status and try again once it settles."
+		}
+		return app.OperationResult{}, derr
 	}
 	return app.OperationResult{
 		Operation:      operation,
@@ -288,7 +306,10 @@ func attachDeployments(applications []domain.Application, deployments []domain.D
 }
 
 func (s *Service) downgradeForError(err error, capability string) {
-	if !domain.IsKind(err, domain.ErrorForbidden) && !domain.IsKind(err, domain.ErrorNotFound) {
+	// Only a 403 says anything about the token. A 404 is about one stale
+	// resource (application deleted mid-session, deployment pruned) and must
+	// not disable the capability for every other resource.
+	if !domain.IsKind(err, domain.ErrorForbidden) {
 		return
 	}
 	s.mu.Lock()


### PR DESCRIPTION
## Summary
- Runtime logs for a not-running application (e.g. mid-deploy, status *Starting*) returned the generic "Request rejected" copy; the 400 now explains that there is no running container and points at the deployment log instead.
- Lifecycle endpoints (restart/start/stop) get the same treatment: a 400 there means "wrong state", not "malformed request", so the error now says so and suggests refreshing.
- `downgradeForError` no longer treats 404 as a permission signal — a stale resource (application deleted mid-session) was disabling the capability for every other application until restart. Docs (`docs/coolify-api.md`) only ever promised downgrade on 403.

Coolify's error body message is deliberately not surfaced: the "response bodies never reach errors" invariant is enforced by `TestHTTPErrorDoesNotExposeResponseBody`, so the copy is rewritten per endpoint in the service layer instead.

## Test plan
- [x] `make check` (fmt, vet, lint, tests, build)
- [x] New `TestValidationErrorsGetStateAwareCopy` covers both rewrites
- [x] New `TestNotFoundDoesNotDowngradeCapabilities` covers the 404 fix