### PR TITLE
Fix always-empty Deployments view

### DIFF
--- a/internal/coolify/deployments_decode_test.go
+++ b/internal/coolify/deployments_decode_test.go
@@ -1,0 +1,99 @@
+package coolify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Coolify wraps per-application deployment history in {count, deployments}
+// (DeployController::get_application_deployments), and the running-queue
+// endpoint serialises a key-preserving Laravel collection, which json_encode
+// turns into a keyed object whenever sortBy reorders the rows. Both shapes
+// must decode; a bare array must keep working for older instances.
+func TestDeploymentsDecodeRealCoolifyShapes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/deployments/applications/app-1":
+			_, _ = fmt.Fprint(w, `{"count":2,"deployments":[
+				{"deployment_uuid":"dep-2","application_id":"app-1","status":"finished","created_at":"2026-08-05T10:00:00Z"},
+				{"deployment_uuid":"dep-1","application_id":"app-1","status":"failed","created_at":"2026-08-04T10:00:00Z"}
+			]}`)
+		case "/api/v1/deployments":
+			_, _ = fmt.Fprint(w, `{
+				"1":{"deployment_uuid":"dep-3","application_id":"app-1","status":"in_progress","created_at":"2026-08-06T10:00:00Z"},
+				"0":{"deployment_uuid":"dep-4","application_id":"app-2","status":"queued","created_at":"2026-08-06T10:01:00Z"}
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	service := newTestService(t, server, time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
+
+	history, err := service.Deployments(context.Background(), "app-1", 10)
+	if err != nil {
+		t.Fatalf("Deployments() error = %v", err)
+	}
+	if len(history) != 2 || history[0].UUID != "dep-2" {
+		t.Fatalf("history = %#v", history)
+	}
+
+	running, err := service.listDeployments(context.Background())
+	if err != nil {
+		t.Fatalf("listDeployments() error = %v", err)
+	}
+	if len(running) != 2 || running[0].UUID != "dep-4" {
+		t.Fatalf("running = %#v", running)
+	}
+}
+
+// The fleet Deployments screen is fed from Dashboard, and the running-queue
+// endpoint never returns finished work - history must be merged in from the
+// per-application endpoints, deduplicated against the live queue.
+func TestDashboardMergesPerApplicationHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/applications":
+			_, _ = fmt.Fprint(w, `[
+				{"uuid":"app-1","name":"api","status":"running:healthy"},
+				{"uuid":"app-2","name":"web","status":"running:healthy"}
+			]`)
+		case "/api/v1/deployments":
+			_, _ = fmt.Fprint(w, `[{"deployment_uuid":"dep-live","application_id":"app-1","status":"in_progress","created_at":"2026-08-06T12:00:00Z"}]`)
+		case "/api/v1/deployments/applications/app-1":
+			_, _ = fmt.Fprint(w, `{"count":2,"deployments":[
+				{"deployment_uuid":"dep-live","application_id":"app-1","status":"in_progress","created_at":"2026-08-06T12:00:00Z"},
+				{"deployment_uuid":"dep-old","application_id":"app-1","status":"finished","created_at":"2026-08-05T12:00:00Z"}
+			]}`)
+		case "/api/v1/deployments/applications/app-2":
+			_, _ = fmt.Fprint(w, `{"count":1,"deployments":[
+				{"deployment_uuid":"dep-web","application_id":"app-2","status":"failed","created_at":"2026-08-06T09:00:00Z"}
+			]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	service := newTestService(t, server, time.Date(2026, 8, 6, 13, 0, 0, 0, time.UTC))
+	dashboard, err := service.Dashboard(context.Background())
+	if err != nil {
+		t.Fatalf("Dashboard() error = %v", err)
+	}
+	if len(dashboard.ActiveDeployments) != 1 || dashboard.ActiveDeployments[0].UUID != "dep-live" {
+		t.Fatalf("active = %#v", dashboard.ActiveDeployments)
+	}
+	got := make([]string, 0, len(dashboard.RecentDeployments))
+	for _, d := range dashboard.RecentDeployments {
+		got = append(got, d.UUID)
+	}
+	want := []string{"dep-live", "dep-web", "dep-old"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("recent = %v, want %v", got, want)
+	}
+}

--- a/internal/coolify/dto.go
+++ b/internal/coolify/dto.go
@@ -1,5 +1,7 @@
 package coolify
 
+import "encoding/json"
+
 type applicationDTO struct {
 	ID                  int     `json:"id"`
 	UUID                string  `json:"uuid"`
@@ -40,6 +42,39 @@ type deploymentDTO struct {
 	CreatedAt       string `json:"created_at"`
 	UpdatedAt       string `json:"updated_at"`
 	Logs            string `json:"logs"`
+}
+
+// deploymentListDTO accepts every shape Coolify uses for a deployment list:
+// a bare array, the {count, deployments} wrapper of the per-application
+// history endpoint, and the keyed object json_encode produces when the
+// running-queue endpoint serialises a key-preserving Laravel collection that
+// sortBy has reordered.
+type deploymentListDTO []deploymentDTO
+
+func (l *deploymentListDTO) UnmarshalJSON(data []byte) error {
+	var plain []deploymentDTO
+	if err := json.Unmarshal(data, &plain); err == nil {
+		*l = plain
+		return nil
+	}
+	var wrapped struct {
+		Deployments []deploymentDTO `json:"deployments"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Deployments != nil {
+		*l = wrapped.Deployments
+		return nil
+	}
+	var keyed map[string]deploymentDTO
+	if err := json.Unmarshal(data, &keyed); err != nil {
+		return err
+	}
+	// Map order is irrelevant: mapDeployments re-sorts newest first anyway.
+	items := make([]deploymentDTO, 0, len(keyed))
+	for _, item := range keyed {
+		items = append(items, item)
+	}
+	*l = items
+	return nil
 }
 
 type teamDTO struct {

--- a/internal/coolify/service.go
+++ b/internal/coolify/service.go
@@ -109,6 +109,10 @@ func (s *Service) Dashboard(ctx context.Context) (app.DashboardSnapshot, error) 
 		warnings = append(warnings, "Deployment status is temporarily unavailable.")
 		deployments = []domain.Deployment{}
 	}
+	// The running-queue endpoint only knows about in_progress and queued
+	// deployments, so finished history has to come from one request per
+	// application (Coolify has no fleet-wide history endpoint).
+	deployments = mergeDeployments(deployments, s.fleetRecentDeployments(ctx, applications))
 	active, recent := splitDeployments(deployments, 100)
 	attachDeployments(applications, deployments, s.now())
 	return app.DashboardSnapshot{
@@ -164,7 +168,7 @@ func (s *Service) RuntimeLogs(ctx context.Context, appUUID string, lines int) (a
 
 func (s *Service) Deployments(ctx context.Context, appUUID string, limit int) ([]domain.Deployment, error) {
 	query := url.Values{"skip": {"0"}, "take": {strconv.Itoa(limit)}}
-	dtos := []deploymentDTO{}
+	dtos := deploymentListDTO{}
 	path := "deployments/applications/" + url.PathEscape(appUUID)
 	if err := s.client.getJSON(ctx, path, query, &dtos); err != nil {
 		return nil, domain.AsError(err).WithOperation("list deployments")
@@ -251,7 +255,7 @@ func (s *Service) listApplications(ctx context.Context) ([]domain.Application, e
 }
 
 func (s *Service) listDeployments(ctx context.Context) ([]domain.Deployment, error) {
-	dtos := []deploymentDTO{}
+	dtos := deploymentListDTO{}
 	if err := s.client.getJSON(ctx, "deployments", nil, &dtos); err != nil {
 		return nil, err
 	}
@@ -269,6 +273,61 @@ func mapDeployments(dtos []deploymentDTO) []domain.Deployment {
 		return deployments[i].CreatedAt.After(deployments[j].CreatedAt)
 	})
 	return deployments
+}
+
+// fleetRecentDeployments fans out one bounded history request per application,
+// mirroring the fleet-tail approach of ADR 0007: a fixed worker pool, and each
+// application is best-effort - one failing (or freshly deleted) application
+// must not blank the history of every other one. A 403 still downgrades the
+// capability so the UI can explain itself.
+func (s *Service) fleetRecentDeployments(ctx context.Context, applications []domain.Application) []domain.Deployment {
+	const workers = 8
+	// 5 per application is enough: splitDeployments caps the merged list at 100
+	// anyway, and deeper per-app history stays on the application detail.
+	const perApplication = 5
+
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	all := []domain.Deployment{}
+	for _, application := range applications {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			items, err := s.Deployments(ctx, application.UUID, perApplication)
+			if err != nil {
+				s.downgradeForError(err, "deployments")
+				return
+			}
+			mu.Lock()
+			all = append(all, items...)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return all
+}
+
+// mergeDeployments joins the live queue with fetched history, first list wins
+// on duplicate UUIDs, newest first overall.
+func mergeDeployments(primary, secondary []domain.Deployment) []domain.Deployment {
+	seen := make(map[string]bool, len(primary)+len(secondary))
+	merged := make([]domain.Deployment, 0, len(primary)+len(secondary))
+	for _, list := range [][]domain.Deployment{primary, secondary} {
+		for _, d := range list {
+			if d.UUID != "" && seen[d.UUID] {
+				continue
+			}
+			seen[d.UUID] = true
+			merged = append(merged, d)
+		}
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		return merged[i].CreatedAt.After(merged[j].CreatedAt)
+	})
+	return merged
 }
 
 // splitDeployments separates the live queue from a bounded recent history


### PR DESCRIPTION
## Problem

The Deployments section (key 2) was always empty - even with dozens of past deployments and even while a deployment was running.

## Root causes (verified against Coolify source)

1. `GET /deployments/applications/{uuid}` returns a `{count, deployments}` wrapper, but cooldeck decoded a bare array - per-application history always failed to decode and was silently dropped.
2. `GET /deployments` serialises a key-preserving Laravel collection (`->get()->sortBy('id')`); whenever rows arrive out of id order, `json_encode` emits a keyed object instead of an array - the decode failed exactly when deployments were running.
3. `GET /deployments` only ever returns `in_progress`/`queued` items, so the fleet screen could never show finished history by design of the endpoint.

## Fix

- `deploymentListDTO` with a tolerant `UnmarshalJSON`: bare array, `{deployments}` wrapper, and keyed object all decode.
- `Dashboard` now merges the live queue with per-application history (one bounded request per application, worker pool of 8, best-effort per app, in the spirit of ADR 0007), deduplicated by UUID, newest first.

## Tests

- `TestDeploymentsDecodeRealCoolifyShapes` - real response shapes, failed before the fix.
- `TestDashboardMergesPerApplicationHistory` - merge + dedupe of live queue vs history.
- `make check` passes.