### PR TITLE
Add fleet timeline, env drift comparison and fleet snapshot

### DIFF
--- a/internal/app/demo/demo.go
+++ b/internal/app/demo/demo.go
@@ -226,6 +226,38 @@ func (s *Service) DeploymentLogs(ctx context.Context, deploymentUUID string) (ap
 		WithOperation("get deployment logs")
 }
 
+// EnvVars implements app.Service. The demo fleet shares a common baseline of
+// variables with deliberate per-application drift, so the env comparison has
+// something interesting to show.
+func (s *Service) EnvVars(ctx context.Context, appUUID string) ([]domain.EnvVar, error) {
+	if err := s.simulate(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, a := range s.apps {
+		if a.UUID != appUUID {
+			continue
+		}
+		vars := []domain.EnvVar{
+			{Key: "APP_ENV", Fingerprint: domain.FingerprintEnvValue("production")},
+			{Key: "DATABASE_URL", Fingerprint: domain.FingerprintEnvValue("postgres://" + a.UUID)},
+			{Key: "REDIS_URL", Fingerprint: domain.FingerprintEnvValue("redis://cache:6379")},
+			// LOG_LEVEL drifts across the fleet so a comparison shows a
+			// different-value row, not just missing keys.
+			{Key: "LOG_LEVEL", Fingerprint: domain.FingerprintEnvValue([]string{"info", "warn", "debug"}[i%3])},
+		}
+		// Every other application is missing its SENTRY_DSN - the classic
+		// "works on staging" drift.
+		if i%2 == 0 {
+			vars = append(vars, domain.EnvVar{Key: "SENTRY_DSN", Fingerprint: domain.FingerprintEnvValue("dsn-" + a.UUID)})
+		}
+		return vars, nil
+	}
+	return nil, domain.NewError(domain.ErrorNotFound, nil).WithOperation("list environment variables")
+}
+
 // Deploy implements app.Service. Nothing is really deployed: a queued
 // deployment is inserted so the UI can follow it through to completion.
 func (s *Service) Deploy(ctx context.Context, appUUID string, opts app.DeployOptions) (app.OperationResult, error) {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -20,6 +20,7 @@ type Capabilities struct {
 	ApplicationLogs bool
 	Deployments     bool
 	DeploymentLogs  bool
+	EnvVars         bool
 	Deploy          bool
 	Restart         bool
 	StartStop       bool
@@ -29,7 +30,7 @@ type Capabilities struct {
 func FullCapabilities() Capabilities {
 	return Capabilities{
 		Applications: true, ApplicationLogs: true,
-		Deployments: true, DeploymentLogs: true,
+		Deployments: true, DeploymentLogs: true, EnvVars: true,
 		Deploy: true, Restart: true, StartStop: true,
 	}
 }
@@ -127,6 +128,11 @@ type Service interface {
 	RuntimeLogs(ctx context.Context, appUUID string, lines int) (LogSnapshot, error)
 	Deployments(ctx context.Context, appUUID string, limit int) ([]domain.Deployment, error)
 	DeploymentLogs(ctx context.Context, deploymentUUID string) (LogSnapshot, error)
+
+	// EnvVars lists an application's environment variables reduced to keys and
+	// value fingerprints. Implementations must never let the raw values escape
+	// this call: hashing happens at the API boundary.
+	EnvVars(ctx context.Context, appUUID string) ([]domain.EnvVar, error)
 
 	Deploy(ctx context.Context, appUUID string, opts DeployOptions) (OperationResult, error)
 	Restart(ctx context.Context, appUUID string) (OperationResult, error)

--- a/internal/coolify/dto.go
+++ b/internal/coolify/dto.go
@@ -26,6 +26,15 @@ type applicationDTO struct {
 	UpdatedAt           string  `json:"updated_at"`
 }
 
+// envDTO carries one environment variable. The value never leaves this
+// package: mapping reduces it to a fingerprint immediately.
+type envDTO struct {
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	IsBuildTime bool   `json:"is_build_time"`
+	IsPreview   bool   `json:"is_preview"`
+}
+
 type deploymentDTO struct {
 	DeploymentUUID  string `json:"deployment_uuid"`
 	ApplicationID   string `json:"application_id"`

--- a/internal/coolify/service.go
+++ b/internal/coolify/service.go
@@ -185,6 +185,28 @@ func (s *Service) DeploymentLogs(ctx context.Context, deploymentUUID string) (ap
 	return app.LogSnapshot{Lines: parseDeploymentLogs(dto.Logs), LoadedAt: s.now()}, nil
 }
 
+// EnvVars lists an application's environment variables. Raw values are hashed
+// into fingerprints here, at the API boundary, so nothing above this call can
+// ever see or leak them.
+func (s *Service) EnvVars(ctx context.Context, appUUID string) ([]domain.EnvVar, error) {
+	dtos := []envDTO{}
+	path := "applications/" + url.PathEscape(appUUID) + "/envs"
+	if err := s.client.getJSON(ctx, path, nil, &dtos); err != nil {
+		s.downgradeForError(err, "envs")
+		return nil, domain.AsError(err).WithOperation("list environment variables")
+	}
+	vars := make([]domain.EnvVar, 0, len(dtos))
+	for _, dto := range dtos {
+		vars = append(vars, domain.EnvVar{
+			Key:         dto.Key,
+			Fingerprint: domain.FingerprintEnvValue(dto.Value),
+			IsBuildTime: dto.IsBuildTime,
+			IsPreview:   dto.IsPreview,
+		})
+	}
+	return vars, nil
+}
+
 func (s *Service) Deploy(ctx context.Context, appUUID string, opts app.DeployOptions) (app.OperationResult, error) {
 	query := url.Values{"uuid": {appUUID}, "force": {strconv.FormatBool(opts.Force)}}
 	dto := deployResponseDTO{}
@@ -382,6 +404,8 @@ func (s *Service) downgradeForError(err error, capability string) {
 		s.capabilities.Deployments = false
 	case "deployment_logs":
 		s.capabilities.DeploymentLogs = false
+	case "envs":
+		s.capabilities.EnvVars = false
 	case "deploy":
 		s.capabilities.Deploy = false
 	case "restart":

--- a/internal/domain/env.go
+++ b/internal/domain/env.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+)
+
+// EnvVar is one environment variable of an application, reduced to what a
+// comparison needs. The value itself is never carried: only a fingerprint,
+// so two variables can be compared for equality without any secret ever
+// reaching the UI, logs or clipboard.
+type EnvVar struct {
+	Key string
+	// Fingerprint is a short, one-way digest of the value. Equal values give
+	// equal fingerprints; the value cannot be recovered from it.
+	Fingerprint string
+	// IsBuildTime marks a variable only available during the build.
+	IsBuildTime bool
+	// IsPreview marks a variable scoped to preview deployments.
+	IsPreview bool
+}
+
+// FingerprintEnvValue digests a value for drift comparison. Eight hex
+// characters are plenty for telling two configurations apart and useless for
+// brute-forcing the value back.
+func FingerprintEnvValue(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:4])
+}
+
+// EnvDiff is the outcome of comparing two applications' environments. All
+// slices are sorted by key so rendering and tests are deterministic.
+type EnvDiff struct {
+	// OnlyInA and OnlyInB list keys present on one side only.
+	OnlyInA []string
+	OnlyInB []string
+	// Different lists keys present on both sides with differing values.
+	Different []string
+	// Same counts keys that match on both sides; the keys themselves are not
+	// interesting, the reassurance is.
+	Same int
+}
+
+// InSync reports that the two environments carry the same keys and values.
+func (d EnvDiff) InSync() bool {
+	return len(d.OnlyInA) == 0 && len(d.OnlyInB) == 0 && len(d.Different) == 0
+}
+
+// DiffEnv compares two environments by key and value fingerprint. Preview
+// variables are compared like any other: a drifted preview variable is still
+// drift.
+func DiffEnv(a, b []EnvVar) EnvDiff {
+	byKey := func(vars []EnvVar) map[string]string {
+		m := make(map[string]string, len(vars))
+		for _, v := range vars {
+			m[v.Key] = v.Fingerprint
+		}
+		return m
+	}
+	am, bm := byKey(a), byKey(b)
+
+	var d EnvDiff
+	for key, fp := range am {
+		other, ok := bm[key]
+		switch {
+		case !ok:
+			d.OnlyInA = append(d.OnlyInA, key)
+		case other != fp:
+			d.Different = append(d.Different, key)
+		default:
+			d.Same++
+		}
+	}
+	for key := range bm {
+		if _, ok := am[key]; !ok {
+			d.OnlyInB = append(d.OnlyInB, key)
+		}
+	}
+	slices.Sort(d.OnlyInA)
+	slices.Sort(d.OnlyInB)
+	slices.Sort(d.Different)
+	return d
+}

--- a/internal/domain/env_test.go
+++ b/internal/domain/env_test.go
@@ -1,0 +1,59 @@
+package domain
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDiffEnv(t *testing.T) {
+	a := []EnvVar{
+		{Key: "APP_ENV", Fingerprint: FingerprintEnvValue("production")},
+		{Key: "DATABASE_URL", Fingerprint: FingerprintEnvValue("postgres://prod")},
+		{Key: "LOG_LEVEL", Fingerprint: FingerprintEnvValue("warn")},
+		{Key: "SENTRY_DSN", Fingerprint: FingerprintEnvValue("dsn")},
+	}
+	b := []EnvVar{
+		{Key: "APP_ENV", Fingerprint: FingerprintEnvValue("production")},
+		{Key: "DATABASE_URL", Fingerprint: FingerprintEnvValue("postgres://staging")},
+		{Key: "LOG_LEVEL", Fingerprint: FingerprintEnvValue("debug")},
+		{Key: "FEATURE_X", Fingerprint: FingerprintEnvValue("1")},
+	}
+
+	d := DiffEnv(a, b)
+	if got, want := d.OnlyInA, []string{"SENTRY_DSN"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("OnlyInA = %v, want %v", got, want)
+	}
+	if got, want := d.OnlyInB, []string{"FEATURE_X"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("OnlyInB = %v, want %v", got, want)
+	}
+	if got, want := d.Different, []string{"DATABASE_URL", "LOG_LEVEL"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Different = %v, want %v", got, want)
+	}
+	if d.Same != 1 {
+		t.Errorf("Same = %d, want 1", d.Same)
+	}
+	if d.InSync() {
+		t.Error("InSync() = true for drifted environments")
+	}
+}
+
+func TestDiffEnvInSync(t *testing.T) {
+	vars := []EnvVar{{Key: "A", Fingerprint: "x"}, {Key: "B", Fingerprint: "y"}}
+	d := DiffEnv(vars, vars)
+	if !d.InSync() || d.Same != 2 {
+		t.Errorf("identical environments: InSync=%v Same=%d", d.InSync(), d.Same)
+	}
+}
+
+func TestFingerprintEnvValueIsStableAndOpaque(t *testing.T) {
+	fp := FingerprintEnvValue("secret-value")
+	if fp != FingerprintEnvValue("secret-value") {
+		t.Error("fingerprint is not deterministic")
+	}
+	if fp == FingerprintEnvValue("other") {
+		t.Error("distinct values share a fingerprint")
+	}
+	if len(fp) != 8 {
+		t.Errorf("fingerprint length = %d, want 8", len(fp))
+	}
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -240,4 +240,8 @@ func (m *Model) shutdown() {
 		m.cancelOperation()
 		m.cancelOperation = nil
 	}
+	if m.cancelEnvDiff != nil {
+		m.cancelEnvDiff()
+		m.cancelEnvDiff = nil
+	}
 }

--- a/internal/tui/envdiff.go
+++ b/internal/tui/envdiff.go
@@ -1,0 +1,146 @@
+package tui
+
+import (
+	"context"
+	"strconv"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+)
+
+// envDiffResult is the loaded comparison shown in the env drift overlay.
+// Only keys and verdicts are carried; values never reach the TUI layer at all
+// (the Service hashes them at the API boundary).
+type envDiffResult struct {
+	NameA string
+	NameB string
+	Diff  domain.EnvDiff
+}
+
+// envDiffLoadedMsg delivers a finished comparison.
+type envDiffLoadedMsg struct {
+	Seq    uint64
+	Result envDiffResult
+}
+
+// envDiffFailedMsg delivers a failed comparison.
+type envDiffFailedMsg struct {
+	Seq uint64
+	Err *domain.Error
+}
+
+// handleCompareEnv implements the two-press flow on the applications list:
+// the first x marks the baseline application, the second x on another row
+// loads and compares both environments. Pressing x on the baseline unmarks it.
+func (m *Model) handleCompareEnv() tea.Cmd {
+	a, ok := m.apps.Selected()
+	if !ok {
+		return nil
+	}
+	if !m.capabilities.EnvVars {
+		return m.pushToast(components.ToastWarning, "Env compare unavailable", "The token cannot read environment variables.")
+	}
+	switch m.compareBaseUUID {
+	case "":
+		m.compareBaseUUID = a.UUID
+		m.compareBaseName = a.Name
+		return m.pushToast(components.ToastInfo, "Comparing from "+a.Name, "Press x on another application to diff their environments.")
+	case a.UUID:
+		m.compareBaseUUID = ""
+		m.compareBaseName = ""
+		return m.pushToast(components.ToastInfo, "Env compare cancelled", "")
+	default:
+		return m.loadEnvDiff(m.compareBaseUUID, m.compareBaseName, a.UUID, a.Name)
+	}
+}
+
+// loadEnvDiff fetches both environments in one command and diffs them off the
+// event loop. Supersession follows the standard seq + cancel pattern.
+func (m *Model) loadEnvDiff(uuidA, nameA, uuidB, nameB string) tea.Cmd {
+	if m.cancelEnvDiff != nil {
+		m.cancelEnvDiff()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	m.cancelEnvDiff = cancel
+	m.envDiffSeq++
+	seq := m.envDiffSeq
+	service := m.service
+
+	return func() tea.Msg {
+		defer cancel()
+		varsA, err := service.EnvVars(ctx, uuidA)
+		if err != nil {
+			return envDiffFailedMsg{Seq: seq, Err: domain.AsError(err)}
+		}
+		varsB, err := service.EnvVars(ctx, uuidB)
+		if err != nil {
+			return envDiffFailedMsg{Seq: seq, Err: domain.AsError(err)}
+		}
+		return envDiffLoadedMsg{Seq: seq, Result: envDiffResult{
+			NameA: nameA,
+			NameB: nameB,
+			Diff:  domain.DiffEnv(varsA, varsB),
+		}}
+	}
+}
+
+// handleEnvDiffKey drives the open overlay; any dismissal key closes it.
+func (m *Model) handleEnvDiffKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q", "x", "enter":
+		m.envDiff = nil
+	}
+	return m, nil
+}
+
+// overlayEnvDiff places the comparison modal over the frame.
+func (m *Model) overlayEnvDiff(frame string) string {
+	if m.envDiff == nil || m.layout.Width < 28 || m.layout.Height < 10 {
+		return frame
+	}
+	th := m.theme
+	r := m.envDiff
+	width := min(m.layout.Width-4, 64)
+	inner := max(width-4, 20)
+
+	nameA := domain.SanitizeLogText(r.NameA)
+	nameB := domain.SanitizeLogText(r.NameB)
+
+	lines := []string{
+		th.ModalTitle.Render("Env drift"),
+		th.ModalHint.Render(components.Truncate(nameA+" vs "+nameB, inner, th.Sym.Ellipsis)),
+		th.ModalHint.Render("keys and value fingerprints only - values never leave the API client"),
+		"",
+	}
+	section := func(title string, keys []string) {
+		if len(keys) == 0 {
+			return
+		}
+		lines = append(lines, th.PaletteGroup.Render(title))
+		for _, k := range keys {
+			lines = append(lines, th.ModalBody.Render("  "+components.Truncate(domain.SanitizeLogText(k), inner-2, th.Sym.Ellipsis)))
+		}
+		lines = append(lines, "")
+	}
+	section("Only in "+components.Truncate(nameA, 24, th.Sym.Ellipsis), r.Diff.OnlyInA)
+	section("Only in "+components.Truncate(nameB, 24, th.Sym.Ellipsis), r.Diff.OnlyInB)
+	section("Different values", r.Diff.Different)
+	if r.Diff.InSync() {
+		lines = append(lines, th.ModalBody.Render("The environments are in sync."), "")
+	}
+	lines = append(lines,
+		th.ModalHint.Render(strconv.Itoa(r.Diff.Same)+" matching  ·  esc close"))
+
+	maxBody := max(m.layout.Height-6, 6)
+	if len(lines) > maxBody {
+		lines = lines[:maxBody]
+	}
+	modal := th.Modal.Width(width).Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+	dimmed := m.theme.Backdrop.Render(lipgloss.JoinVertical(lipgloss.Left, components.Lines(frame)...))
+	x := max((m.layout.Width-lipgloss.Width(modal))/2, 0)
+	y := max((m.layout.Height-lipgloss.Height(modal))/6, 1)
+	return components.Overlay(dimmed, modal, x, y)
+}

--- a/internal/tui/envdiff_test.go
+++ b/internal/tui/envdiff_test.go
@@ -1,0 +1,75 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/resetnak/cooldeck/internal/app/demo"
+	"github.com/resetnak/cooldeck/internal/config"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+)
+
+// TestCompareEnvTwoPressFlow drives the whole feature: mark, pick, load, and
+// render the drift overlay, then dismiss it.
+func TestCompareEnvTwoPressFlow(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	service := demo.New(demo.Options{Now: func() time.Time { return now }})
+	snapshot, err := service.Dashboard(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	model := New(Options{
+		Config:       config.Default(),
+		Service:      service,
+		InstanceName: "Demo",
+		Demo:         true,
+		ASCII:        true,
+		Now:          func() time.Time { return now },
+	})
+	model.Update(tea.WindowSizeMsg{Width: 120, Height: 32})
+	model.loading = false
+	model.connection = components.ConnectionOnline
+	model.apps.SetApplications(snapshot.Applications, snapshot.ActiveDeployments, now)
+
+	// First x marks the baseline.
+	if cmd := model.handleCompareEnv(); cmd == nil {
+		t.Fatal("first press produced no feedback toast")
+	}
+	if model.compareBaseUUID == "" {
+		t.Fatal("first press did not mark a baseline")
+	}
+
+	// Second x on another application loads the comparison.
+	model.apps.Move(1)
+	cmd := model.handleCompareEnv()
+	if cmd == nil {
+		t.Fatal("second press produced no load command")
+	}
+	msg, ok := cmd().(envDiffLoadedMsg)
+	if !ok {
+		t.Fatalf("second press produced %T, want envDiffLoadedMsg", cmd())
+	}
+	model.Update(msg)
+	if model.envDiff == nil {
+		t.Fatal("loaded comparison did not open the overlay")
+	}
+
+	plain := ansi.Strip(model.render())
+	if !strings.Contains(plain, "Env drift") {
+		t.Fatalf("overlay missing from render:\n%s", plain)
+	}
+	// The demo fleet drifts SENTRY_DSN between neighbouring applications.
+	if !strings.Contains(plain, "SENTRY_DSN") {
+		t.Fatalf("expected drifted key in overlay:\n%s", plain)
+	}
+
+	model.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if model.envDiff != nil {
+		t.Fatal("esc did not close the overlay")
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -97,6 +97,8 @@ func (m *Model) helpGroups() []helpGroup {
 				{"S", "cycle sort mode"},
 				{"space", "mark for the fleet tail"},
 				{"t", "tail the marked applications"},
+				{"x", "compare env with another application"},
+				{"!", "copy fleet snapshot as markdown"},
 			},
 		},
 		{
@@ -127,6 +129,7 @@ func (m *Model) helpGroups() []helpGroup {
 			Rows: []helpRow{
 				{"enter", "open build log for deployment"},
 				{"a", "toggle active-only / recent history"},
+				{"t", "toggle chronological fleet timeline"},
 				{"c", "copy deployment UUID"},
 			},
 		},

--- a/internal/tui/instance_switch.go
+++ b/internal/tui/instance_switch.go
@@ -65,6 +65,11 @@ func (m *Model) applyInstanceSwitch(msg instanceSwitchedMsg) tea.Cmd {
 	m.filterText = ""
 	m.logSearching = false
 	m.logSearchText = ""
+	// An env comparison must not span two fleets.
+	m.compareBaseUUID = ""
+	m.compareBaseName = ""
+	m.envDiff = nil
+	m.envDiffSeq++
 	m.lastError = nil
 	m.lastSuccess = time.Time{}
 	m.connectionErr = nil

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -36,6 +36,12 @@ type KeyMap struct {
 	Mark key.Binding
 	Tail key.Binding
 
+	// Fleet snapshot.
+	Snapshot key.Binding
+
+	// Env drift comparison.
+	CompareEnv key.Binding
+
 	// Sections.
 	SectionApplications key.Binding
 	SectionDeployments  key.Binding
@@ -55,7 +61,8 @@ type KeyMap struct {
 	Sort        key.Binding
 
 	// Deployments section.
-	DeploymentsActive key.Binding
+	DeploymentsActive   key.Binding
+	DeploymentsTimeline key.Binding
 
 	// Instances section.
 	TestConnection key.Binding
@@ -117,6 +124,9 @@ func DefaultKeyMap() KeyMap {
 		Mark: key.NewBinding(key.WithKeys("space"), key.WithHelp("space", "mark for tail")),
 		Tail: key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tail marked")),
 
+		Snapshot:   key.NewBinding(key.WithKeys("!"), key.WithHelp("!", "fleet snapshot")),
+		CompareEnv: key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "compare env")),
+
 		SectionApplications: key.NewBinding(key.WithKeys("1"), key.WithHelp("1", "applications")),
 		SectionDeployments:  key.NewBinding(key.WithKeys("2"), key.WithHelp("2", "deployments")),
 		SectionInstances:    key.NewBinding(key.WithKeys("3"), key.WithHelp("3", "instances")),
@@ -133,7 +143,8 @@ func DefaultKeyMap() KeyMap {
 		CopyUUID:    key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy UUID")),
 		Sort:        key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "sort")),
 
-		DeploymentsActive: key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "active filter")),
+		DeploymentsActive:   key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "active filter")),
+		DeploymentsTimeline: key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "timeline")),
 
 		TestConnection: key.NewBinding(key.WithKeys("T"), key.WithHelp("T", "test connection")),
 		AddInstance:    key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add instance")),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -177,7 +177,9 @@ type Model struct {
 	tailSeq              uint64
 	deploymentLogsSeq    uint64
 	operationSeq         uint64
+	envDiffSeq           uint64
 	cancelDashboard      context.CancelFunc
+	cancelEnvDiff        context.CancelFunc
 	cancelDetail         context.CancelFunc
 	cancelRuntimeLogs    context.CancelFunc
 	cancelDeploymentLogs context.CancelFunc
@@ -222,6 +224,12 @@ type Model struct {
 
 	pendingAction     *pendingAction
 	operationInFlight bool
+
+	// compareBaseUUID holds the first application picked for an env drift
+	// comparison; envDiff is non-nil while the result overlay is open.
+	compareBaseUUID string
+	compareBaseName string
+	envDiff         *envDiffResult
 
 	// deployStates is the deployment status seen on the previous refresh, keyed
 	// by deployment UUID. It is rebuilt from every snapshot, so it cannot grow
@@ -476,6 +484,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pushToast(components.ToastSuccess, "Action queued", "Coolify accepted the "+msg.Result.Operation+" request."),
 			m.manualRefresh(),
 		)
+
+	case envDiffLoadedMsg:
+		if msg.Seq != m.envDiffSeq {
+			return m, nil
+		}
+		m.cancelEnvDiff = nil
+		m.compareBaseUUID = ""
+		m.compareBaseName = ""
+		m.envDiff = &msg.Result
+		return m, nil
+
+	case envDiffFailedMsg:
+		if msg.Seq != m.envDiffSeq || msg.Err.Kind == domain.ErrorCancelled {
+			return m, nil
+		}
+		m.cancelEnvDiff = nil
+		return m, m.pushToast(components.ToastError, msg.Err.Title, msg.Err.Message)
 
 	case actionFailedMsg:
 		if msg.Seq != m.operationSeq || msg.Err.Kind == domain.ErrorCancelled {

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/resetnak/cooldeck/internal/app"
+	"github.com/resetnak/cooldeck/internal/domain"
+	"github.com/resetnak/cooldeck/internal/tui/components"
+)
+
+// snapshotDeploymentLimit bounds the history section so the snapshot stays
+// pasteable into a chat window.
+const snapshotDeploymentLimit = 20
+
+// copyFleetSnapshot copies a markdown digest of the whole fleet - statuses,
+// recent deployments, recent errors - to the clipboard. It is the panic
+// button: one keypress produces something ready to paste at an AI assistant
+// or a colleague. Secret-free by construction, like the diagnostics export.
+func (m *Model) copyFleetSnapshot() tea.Cmd {
+	if !m.apps.Loaded() {
+		return m.pushToast(components.ToastWarning, "Nothing to snapshot", "The fleet has not loaded yet.")
+	}
+	text := fleetSnapshotMarkdown(m.lastConnection, m.apps.All(), m.deployments.Items(), m.recentErrors, m.now())
+	return m.copyText(text, "Fleet snapshot copied - paste it anywhere")
+}
+
+// fleetSnapshotMarkdown renders the fleet state as markdown. Everything that
+// originated outside cooldeck goes through SanitizeLogText, so a hostile
+// commit message cannot smuggle escape sequences into wherever this is pasted.
+func fleetSnapshotMarkdown(
+	conn app.Connection,
+	applications []domain.Application,
+	deployments []domain.Deployment,
+	recentErrors []string,
+	now time.Time,
+) string {
+	var b strings.Builder
+	b.WriteString("# Fleet snapshot\n\n")
+	if conn.InstanceName != "" {
+		b.WriteString("- Instance: " + domain.SanitizeLogText(conn.InstanceName))
+		if conn.Version != "" {
+			b.WriteString(" (Coolify " + domain.SanitizeLogText(conn.Version) + ")")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("- Taken: " + now.UTC().Format(time.RFC3339) + "\n\n")
+
+	b.WriteString("## Applications\n\n")
+	b.WriteString("| Application | Status | Branch | Last deployment |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, a := range applications {
+		last := "unknown"
+		if a.LastDeployment != nil {
+			last = string(a.LastDeployment.Status) + " " + domain.HumanizeAge(a.LastDeployment.StartedAt, now)
+		}
+		b.WriteString("| " + snapshotCell(a.Name) +
+			" | " + snapshotCell(a.Status.Raw) +
+			" | " + snapshotCell(a.Branch) +
+			" | " + snapshotCell(last) + " |\n")
+	}
+
+	if len(deployments) > 0 {
+		b.WriteString("\n## Recent deployments\n\n")
+		shown := deployments
+		if len(shown) > snapshotDeploymentLimit {
+			shown = shown[:snapshotDeploymentLimit]
+		}
+		for _, d := range shown {
+			line := "- " + snapshotCell(d.ApplicationName) +
+				": " + string(d.Status) +
+				" " + domain.HumanizeAge(d.CreatedAt, now)
+			if msg := strings.TrimSpace(d.CommitMessage); msg != "" {
+				line += " - " + snapshotCell(msg)
+			}
+			b.WriteString(line + "\n")
+		}
+	}
+
+	if len(recentErrors) > 0 {
+		b.WriteString("\n## Recent errors\n\n")
+		for _, e := range recentErrors {
+			b.WriteString("- " + domain.SanitizeLogText(e) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// snapshotCell sanitises a value and keeps it from breaking the markdown table.
+func snapshotCell(s string) string {
+	s = domain.SanitizeLogText(strings.TrimSpace(s))
+	if s == "" {
+		return "-"
+	}
+	return strings.ReplaceAll(s, "|", "\\|")
+}

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -1,0 +1,42 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/resetnak/cooldeck/internal/app"
+	"github.com/resetnak/cooldeck/internal/domain"
+)
+
+func TestFleetSnapshotMarkdown(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	conn := app.Connection{InstanceName: "prod", Version: "4.0.0"}
+	apps := []domain.Application{
+		{Name: "api", Status: domain.ParseStatus("running:healthy"), Branch: "main"},
+		{Name: "worker | pipe", Status: domain.ParseStatus("exited"), Branch: "main"},
+	}
+	deployments := []domain.Deployment{
+		{ApplicationName: "api", Status: domain.DeploymentFinished,
+			CreatedAt: now.Add(-10 * time.Minute), CommitMessage: "fix: \x1b[31mred\x1b[0m things"},
+	}
+
+	got := fleetSnapshotMarkdown(conn, apps, deployments, []string{"Timeout: instance slow"}, now)
+
+	for _, want := range []string{
+		"# Fleet snapshot",
+		"prod (Coolify 4.0.0)",
+		"| api | running:healthy | main |",
+		"worker \\| pipe",
+		"## Recent deployments",
+		"## Recent errors",
+		"Timeout: instance slow",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("snapshot missing %q\n---\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "\x1b") {
+		t.Error("snapshot carries a raw escape sequence")
+	}
+}

--- a/internal/tui/testdata/deployments-active.golden
+++ b/internal/tui/testdata/deployments-active.golden
@@ -37,4 +37,4 @@
                          │
                          │
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  ↑↓  select   enter  open log   a  active filter   c  copy UUID   R  refresh   1  apps   ?  help                                                           1/2
+  ↑↓  select   enter  open log   a  active filter   t  timeline   c  copy UUID   R  refresh   1  apps   ?  help                                             1/2

--- a/internal/tui/testdata/deployments-wide.golden
+++ b/internal/tui/testdata/deployments-wide.golden
@@ -37,4 +37,4 @@
                          │  + Finished   notes-app                      35d4a45  13d 17h... 32s                          manual   feat: add weekly summary endp.
                          │  + Finished   notes-app                      63538d5  15d 2h ago 36s                          manual   fix: correct timezone handlin.
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  ↑↓  select   enter  open log   a  active filter   c  copy UUID   R  refresh   1  apps   ?  help                                                          1/33
+  ↑↓  select   enter  open log   a  active filter   t  timeline   c  copy UUID   R  refresh   1  apps   ?  help                                            1/33

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -41,6 +41,9 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.helpOpen {
 		return m.handleHelpKey(msg)
 	}
+	if m.envDiff != nil {
+		return m.handleEnvDiffKey(msg)
+	}
 	if m.paletteOpen {
 		return m.handlePaletteKey(msg)
 	}
@@ -74,6 +77,9 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keys.Refresh):
 		return m, m.manualRefresh()
+
+	case key.Matches(msg, m.keys.Snapshot):
+		return m, m.copyFleetSnapshot()
 
 	case key.Matches(msg, m.keys.NextPane):
 		m.cycleFocus(1)
@@ -239,6 +245,8 @@ func (m *Model) handleApplicationsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	case key.Matches(msg, m.keys.Tail):
 		return m.openTail()
+	case key.Matches(msg, m.keys.CompareEnv):
+		return m, m.handleCompareEnv()
 	case key.Matches(msg, m.keys.Up):
 		m.apps.Move(-1)
 	case key.Matches(msg, m.keys.Down):
@@ -349,6 +357,12 @@ func (m *Model) handleDeploymentsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			label = "active only"
 		}
 		return m, m.pushToast(components.ToastInfo, "Deployments filter: "+label, "")
+	case key.Matches(msg, m.keys.DeploymentsTimeline):
+		label := "table"
+		if m.deployments.ToggleTimeline() {
+			label = "timeline"
+		}
+		return m, m.pushToast(components.ToastInfo, "Deployments view: "+label, "")
 	case key.Matches(msg, m.keys.Quit), key.Matches(msg, m.keys.Back):
 		return m.gotoSection(SectionApplications)
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -34,6 +34,7 @@ func (m *Model) render() string {
 	frame = m.overlayConfirmation(frame)
 	frame = m.overlayPalette(frame)
 	frame = m.overlayHelp(frame)
+	frame = m.overlayEnvDiff(frame)
 	frame = m.overlayInstanceForm(frame)
 	frame = trimTrailingBlank(frame)
 
@@ -360,6 +361,7 @@ func (m *Model) footerHints() []components.KeyHint {
 			{Key: "↑↓", Desc: "select"},
 			{Key: "enter", Desc: "open log", Short: "open"},
 			{Key: "a", Desc: "active filter", Short: "filter"},
+			{Key: "t", Desc: "timeline"},
 			{Key: "c", Desc: "copy UUID", Short: "copy"},
 			{Key: "R", Desc: "refresh"},
 			{Key: "1", Desc: "apps"},

--- a/internal/tui/views/applications.go
+++ b/internal/tui/views/applications.go
@@ -101,6 +101,12 @@ func (v *Applications) Count() int { return len(v.visible) }
 // Total returns the number of applications before filtering.
 func (v *Applications) Total() int { return len(v.all) }
 
+// All returns every loaded application regardless of filter, for the fleet
+// snapshot.
+func (v *Applications) All() []domain.Application {
+	return append([]domain.Application{}, v.all...)
+}
+
 // Filter returns the active filter.
 func (v *Applications) Filter() domain.Filter { return v.filter }
 

--- a/internal/tui/views/deployments.go
+++ b/internal/tui/views/deployments.go
@@ -20,6 +20,10 @@ type Deployments struct {
 	loaded     bool
 	loadedAt   time.Time
 	activeOnly bool
+	// timeline switches from the status-grouped table to a strictly
+	// chronological view with day separators - one merged story of what
+	// happened across the fleet, newest first.
+	timeline bool
 }
 
 // NewDeployments returns an empty deployments view.
@@ -67,15 +71,41 @@ func (v *Deployments) ToggleActiveOnly() bool {
 // ActiveOnly reports the current filter.
 func (v *Deployments) ActiveOnly() bool { return v.activeOnly }
 
+// ToggleTimeline switches between the status-grouped table and the
+// chronological fleet timeline.
+func (v *Deployments) ToggleTimeline() bool {
+	v.timeline = !v.timeline
+	v.selected = 0
+	return v.timeline
+}
+
+// Timeline reports whether the chronological view is active.
+func (v *Deployments) Timeline() bool { return v.timeline }
+
+// Items returns the full loaded history, for the fleet snapshot.
+func (v *Deployments) Items() []domain.Deployment {
+	return append([]domain.Deployment{}, v.items...)
+}
+
 func (v *Deployments) visible() []domain.Deployment {
-	if !v.activeOnly {
-		return v.items
-	}
-	out := make([]domain.Deployment, 0, len(v.items))
-	for _, d := range v.items {
-		if d.Status.IsActive() {
-			out = append(out, d)
+	out := v.items
+	if v.activeOnly {
+		filtered := make([]domain.Deployment, 0, len(out))
+		for _, d := range out {
+			if d.Status.IsActive() {
+				filtered = append(filtered, d)
+			}
 		}
+		out = filtered
+	}
+	if v.timeline {
+		// The timeline tells the story in the order it happened, so the
+		// active-first grouping of the table gives way to pure chronology.
+		chrono := append([]domain.Deployment{}, out...)
+		slices.SortStableFunc(chrono, func(a, b domain.Deployment) int {
+			return b.CreatedAt.Compare(a.CreatedAt)
+		})
+		return chrono
 	}
 	return out
 }
@@ -160,6 +190,10 @@ func (v *Deployments) Render(th *theme.Theme, width, height int, focused bool, n
 		)
 	}
 
+	if v.timeline {
+		return v.renderTimeline(th, width, height, visible, now)
+	}
+
 	// The baseline is taken from the whole loaded history, not just the visible
 	// rows, so filtering to active-only does not remove the very deployments the
 	// expectation is computed from.
@@ -218,4 +252,59 @@ func (v *Deployments) Render(th *theme.Theme, width, height int, focused bool, n
 	}
 	body := lipgloss.JoinVertical(lipgloss.Left, header, meta, "", table.Render(th, width, max(height-3, 1)))
 	return components.FitBlock(body, width, height)
+}
+
+// renderTimeline draws the chronological fleet timeline: every deployment
+// across every application on one axis, separated by day, newest first.
+func (v *Deployments) renderTimeline(th *theme.Theme, width, height int, visible []domain.Deployment, now time.Time) string {
+	header := th.Title.Render("FLEET TIMELINE")
+	meta := th.Subtle.Render(strconv.Itoa(len(visible)) + " deployments  ·  newest first  ·  t table view")
+
+	// Build the full line list first, remembering which line the cursor is on,
+	// then window it around the selection.
+	lines := make([]string, 0, len(visible)*2)
+	selectedLine := 0
+	lastDay := ""
+	for i, d := range visible {
+		if day := timelineDay(d.CreatedAt, now); day != lastDay {
+			lastDay = day
+			lines = append(lines, th.Subtle.Render(components.Truncate("── "+day+" ", width, th.Sym.Ellipsis)))
+		}
+		row := th.DeploymentStatusText(d.Status) + "  " +
+			components.OrDash(d.ApplicationName) + "  " +
+			th.Subtle.Render(domain.HumanizeAge(d.CreatedAt, now)+"  "+
+				domain.HumanizeDuration(d.Duration(now))+"  "+
+				components.OrDash(d.ShortCommit())) + "  " +
+			components.OrDash(d.CommitMessage)
+		row = components.Truncate("  "+row, width-2, th.Sym.Ellipsis)
+		if i == v.selected {
+			selectedLine = len(lines)
+			row = th.TableRowActive.Render(components.Pad(row, width))
+		}
+		lines = append(lines, row)
+	}
+
+	bodyHeight := max(height-3, 1)
+	start := 0
+	if selectedLine >= bodyHeight {
+		start = selectedLine - bodyHeight + 1
+	}
+	end := min(start+bodyHeight, len(lines))
+	body := lipgloss.JoinVertical(lipgloss.Left, lines[start:end]...)
+	block := lipgloss.JoinVertical(lipgloss.Left, header, meta, "", body)
+	return components.FitBlock(block, width, height)
+}
+
+// timelineDay buckets a timestamp into a relative day label. Relative labels
+// keep golden snapshots host-independent where absolute dates would not.
+func timelineDay(t, now time.Time) string {
+	days := int(now.Sub(t).Hours() / 24)
+	switch {
+	case days <= 0:
+		return "Today"
+	case days == 1:
+		return "Yesterday"
+	default:
+		return strconv.Itoa(days) + " days ago"
+	}
 }

--- a/internal/tui/views/deployments_test.go
+++ b/internal/tui/views/deployments_test.go
@@ -69,3 +69,25 @@ func TestSelectionFollowsADeploymentThatSettles(t *testing.T) {
 		t.Fatalf("selection = %q (ok=%v), want watched", selected.UUID, ok)
 	}
 }
+
+func TestTimelineOrdersChronologically(t *testing.T) {
+	view := NewDeployments()
+	now := time.Now()
+
+	older := deployment("older-active", domain.DeploymentInProgress)
+	older.CreatedAt = now.Add(-2 * time.Hour)
+	newer := deployment("newer-finished", domain.DeploymentFinished)
+	newer.CreatedAt = now.Add(-5 * time.Minute)
+	view.SetItems([]domain.Deployment{older, newer}, now)
+
+	// The table leads with the active build; the timeline must not.
+	if got := uuids(view.visible()); got[0] != "older-active" {
+		t.Fatalf("table order = %v, want active first", got)
+	}
+	if !view.ToggleTimeline() {
+		t.Fatal("ToggleTimeline() = false on first toggle")
+	}
+	if got := uuids(view.visible()); got[0] != "newer-finished" {
+		t.Fatalf("timeline order = %v, want newest first", got)
+	}
+}


### PR DESCRIPTION
## What

Three new features, all behind the existing `app.Service` seam:

### 1. Fleet timeline (`t` in Deployments)
The deployments section can flip from the status-grouped table to a strictly chronological view of every deployment across the fleet, newest first, with relative day separators (Today / Yesterday / N days ago). One merged story of what happened - useful when reconstructing an incident ("backend deployed at 14:32, frontend started failing at 14:33").

### 2. Env drift comparison (`x` in Applications)
Two-press flow: mark a baseline application with `x`, press `x` on another one, and an overlay shows which environment variable keys exist only on one side and which differ in value. **Values never leave `internal/coolify` / the demo service** - they are reduced to 8-hex SHA-256 fingerprints at the API boundary (`domain.FingerprintEnvValue`), so the TUI layer compares verdicts, not secrets. New `Service.EnvVars` method, new `EnvVars` capability with the standard 403 downgrade, new `GET applications/{uuid}/envs` client call.

### 3. Fleet snapshot (`!`, global)
One keypress copies a markdown digest of the fleet - connection info, application statuses, recent deployments, recent errors - to the clipboard, ready to paste at an AI assistant or a colleague. Secret-free by construction, all external text passes through `SanitizeLogText`.

## Notes

- Env comparison state is cleared on instance switch so fleets cannot mix; the in-flight diff request follows the standard seq + cancel supersession pattern and is cancelled on shutdown.
- Demo service ships deterministic env drift (`LOG_LEVEL` varies, every other app is missing `SENTRY_DSN`) so the feature is demonstrable offline.
- Golden diff is limited to the new `t timeline` footer hint in the two deployments snapshots - reviewed, expected.
- MCP server intentionally does not expose an envs tool yet; can follow in a separate PR.

## Testing

`make check` passes (fmt, vet, staticcheck + golangci-lint, full test suite, build). New tests: `TestDiffEnv`\*, `TestFleetSnapshotMarkdown`, `TestTimelineOrdersChronologically`, and `TestCompareEnvTwoPressFlow` driving the whole mark→load→overlay→dismiss flow.